### PR TITLE
feat: AddButton 컴포넌트 추가, 카테고리 모달 열기/닫기 기능 추가

### DIFF
--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from 'react';
 import { FaPlus, FaTimes } from 'react-icons/fa';
-import { IoMdTrash } from 'react-icons/io';
-import { HiPencil } from 'react-icons/hi';
-import { PiTagChevronFill } from 'react-icons/pi';
 import { FaCheck } from 'react-icons/fa6';
+import { HiPencil } from 'react-icons/hi';
+import { IoMdTrash } from 'react-icons/io';
+import { PiTagChevronFill } from 'react-icons/pi';
 
 export default function CategoryModal({
   categories: initialCategories,
@@ -157,7 +157,7 @@ export default function CategoryModal({
   };
 
   return (
-    <div className="flex flex-col w-[300px] h-auto min-h-[200px] max-h-[400px] p-4 border border-gray-300 rounded-xs overflow-y-auto">
+    <div className="bg-white flex flex-col w-[300px] h-auto min-h-[200px] max-h-[400px] p-4 border border-gray-300 rounded-xs overflow-y-auto">
       <div className="flex justify-between mb-2">
         <h1 className="text-lg font-semibold">Category List</h1>
         <div
@@ -218,7 +218,7 @@ export default function CategoryModal({
                     <PiTagChevronFill />
                   )}
                 </div>
-                
+
                 {isEditing ? (
                   <input
                     type="text"

--- a/src/components/common/AddButton.tsx
+++ b/src/components/common/AddButton.tsx
@@ -1,0 +1,15 @@
+import { CiCirclePlus } from 'react-icons/ci';
+
+interface PlusButtonProps {
+  className?: string;
+  onClick?: () => void;
+  label: string;
+}
+
+export default function AddButton({ className, onClick, label }: PlusButtonProps) {
+  return (
+    <button className={`cursor-pointer ${className}`} onClick={onClick} aria-label={label}>
+      <CiCirclePlus size={30} />
+    </button>
+  );
+}

--- a/src/components/memo-editor/MemoCreateModal.tsx
+++ b/src/components/memo-editor/MemoCreateModal.tsx
@@ -6,6 +6,7 @@ import CrossButton from '@/components/common/CrossButton';
 import InputField from '@/components/common/InputField';
 import MarkDownEditor from '@/components/MarkdownEditor';
 import { Modal } from '@/components/Modal';
+import useCategories from '@/hooks/useCategories';
 import type { MemoProps } from '@/types/memo';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
@@ -40,7 +41,9 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
   }, [memoData, onClose, router]);
 
   const [isOpenCategoryModal, setIsOpenCategoryModal] = useState(false);
-  // 카테고리 모달 열기
+
+  const { categories, isLoading } = useCategories();
+
   const openCategoryModal = useCallback(() => {
     setIsOpenCategoryModal(true);
   }, []);
@@ -66,7 +69,6 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
           onChange={e => setMemoData(prev => ({ ...prev, title: e.target.value }))}
         />
       </div>
-
       <div className="mb-4 relative">
         <InputField
           placeholder="카테고리"
@@ -79,14 +81,17 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
           className="absolute -top-1 right-0"
           label="카테고리 추가"
         />
-        {isOpenCategoryModal && (
-          <div className="absolute top-4 right-1 z-50">
-            <CategoryModal
-              categories={['기타', '개발', '일상', '공부']}
-              onClose={() => setIsOpenCategoryModal(false)}
-            />
-          </div>
-        )}
+        {isOpenCategoryModal &&
+          (isLoading ? (
+            <div className="text-gray-500">카테고리 불러오는 중...</div>
+          ) : (
+            <div className="absolute top-4 right-1 z-51">
+              <CategoryModal
+                onClose={() => setIsOpenCategoryModal(false)}
+                categories={categories}
+              />
+            </div>
+          ))}
       </div>
       <MarkDownEditor
         value={memoData.content}

--- a/src/components/memo-editor/MemoCreateModal.tsx
+++ b/src/components/memo-editor/MemoCreateModal.tsx
@@ -22,10 +22,11 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
   });
 
   const router = useRouter();
+
   const submitMemo = useCallback(async () => {
     onClose();
     if (!memoData.title || !memoData.content) {
-      console.error('메모 제목, 내용, 카테고리는 필수입니다.');
+      console.error('메모 제목과 내용은 필수입니다.');
       return;
     }
     try {
@@ -35,11 +36,6 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
       console.error('메모 생성 중 오류 발생:', error);
       //TODO: 사용자에게 오류 메시지를 표시하는 로직 추가 필요
     }
-    setMemoData({
-      title: '',
-      content: '',
-      category: '',
-    });
     router.push('/');
   }, [memoData, onClose, router]);
 

--- a/src/components/memo-editor/MemoCreateModal.tsx
+++ b/src/components/memo-editor/MemoCreateModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { fetchCreateMemo } from '@/action';
+import CategoryModal from '@/components/category/CategoryModal';
+import AddButton from '@/components/common/AddButton';
 import CrossButton from '@/components/common/CrossButton';
 import InputField from '@/components/common/InputField';
 import MarkDownEditor from '@/components/MarkdownEditor';
@@ -22,7 +24,7 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
   const router = useRouter();
   const submitMemo = useCallback(async () => {
     onClose();
-    if (!memoData.title || !memoData.content || !memoData.category) {
+    if (!memoData.title || !memoData.content) {
       console.error('메모 제목, 내용, 카테고리는 필수입니다.');
       return;
     }
@@ -40,6 +42,12 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
     });
     router.push('/');
   }, [memoData, onClose, router]);
+
+  const [isOpenCategoryModal, setIsOpenCategoryModal] = useState(false);
+  // 카테고리 모달 열기
+  const openCategoryModal = useCallback(() => {
+    setIsOpenCategoryModal(true);
+  }, []);
 
   return (
     <Modal
@@ -63,13 +71,26 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
         />
       </div>
 
-      <div className="mb-4">
+      <div className="mb-4 relative">
         <InputField
           placeholder="카테고리"
           label="메모 카테고리"
           value={memoData.category}
           onChange={e => setMemoData(prev => ({ ...prev, category: e.target.value }))}
         />
+        <AddButton
+          onClick={openCategoryModal}
+          className="absolute -top-1 right-0"
+          label="카테고리 추가"
+        />
+        {isOpenCategoryModal && (
+          <div className="absolute top-4 right-1 z-50">
+            <CategoryModal
+              categories={['기타', '개발', '일상', '공부']}
+              onClose={() => setIsOpenCategoryModal(false)}
+            />
+          </div>
+        )}
       </div>
       <MarkDownEditor
         value={memoData.content}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+const fetchCategories = async (): Promise<string[]> => {
+  try {
+    const response = await fetch('/api/categories');
+    if (!response.ok) {
+      throw new Error(`카테고리 가져오기 실패: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.categories;
+  } catch (error) {
+    console.error('카테고리 가져오기 실패:', error);
+    return [];
+  }
+};
+
+export default function useCategories() {
+  const [categories, setCategories] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const fetchedCategories = await fetchCategories();
+      setCategories(fetchedCategories);
+      setIsLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  return { categories, isLoading };
+}


### PR DESCRIPTION
- 이 커밋은 MemoCreateModal 컴포넌트에 카테고리 추가 기능을 구현중
- + 버튼 클릭 시 카테고리 모달이 열리고, 카테고리를 추가할 수 있는 기능을 추가할 예정

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 메모 생성 모달에서 카테고리 관리 기능이 추가되었습니다. 이제 카테고리 입력란 옆의 버튼을 통해 카테고리 모달을 열고, 미리 정의된 카테고리를 선택할 수 있습니다.
  - 새로운 "AddButton" 컴포넌트가 도입되어, 다양한 위치에서 플러스 아이콘 버튼을 사용할 수 있습니다.

- **Style**
  - 카테고리 모달의 배경색이 흰색으로 변경되어 시각적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->