### PR TITLE
[feat] 메모 삭제 기능 추가 및 삭제 버튼 추가

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -15,29 +15,33 @@ interface MarkDownEditorProps {
   value?: string;
   onChange?: (value: string | undefined) => void;
   markDownProps?: React.ComponentProps<typeof MDEditor>;
+  defaultMode?: PreviewType;
 }
 
-export default function MarkDownEditor({ value, onChange, markDownProps }: MarkDownEditorProps) {
+const getPreviewMode = (width: number, defaultMode: PreviewType): PreviewType => {
+  if (width <= 768) {
+    return 'edit';
+  }
+  return defaultMode;
+};
+
+export default function MarkDownEditor({
+  value,
+  onChange,
+  markDownProps,
+  defaultMode = 'live',
+}: MarkDownEditorProps) {
   const { width } = useWindowSize();
-  const editorStyle =
-    width <= 768
-      ? {
-          height: '80%',
-          preview: 'edit',
-        }
-      : {
-          height: '50vh',
-          preview: 'live',
-        };
+  const previewMode = getPreviewMode(width, defaultMode);
+  const editorHeight = width <= 768 ? '87%' : '50vh';
 
   return (
     <MDEditor
       data-color-mode="light"
       value={value}
       onChange={onChange}
-      height={editorStyle.height}
-      style={{ height: editorStyle.height }}
-      preview={editorStyle.preview as PreviewType}
+      height={editorHeight}
+      preview={previewMode as PreviewType}
       autoFocus
       autoFocusEnd
       {...markDownProps}

--- a/src/components/common/DeleteButton.tsx
+++ b/src/components/common/DeleteButton.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/cn';
+import { MdDelete } from 'react-icons/md';
+
+interface DeleteButtonProps {
+  onClick: (
+    e?: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>,
+  ) => void;
+  label: string;
+  className?: string;
+}
+
+export default function DeleteButton({ onClick, label, className }: DeleteButtonProps) {
+  return (
+    <button
+      className={cn('p-2 rounded-full hover:bg-red-200/70 transition-colors', className)}
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+    >
+      <MdDelete className="h-[22px] w-[22px] text-red-600" />
+    </button>
+  );
+}

--- a/src/components/memo-editor/MemoUpdateModal.tsx
+++ b/src/components/memo-editor/MemoUpdateModal.tsx
@@ -16,7 +16,7 @@ interface MemoUpdateModalProps {
   id: string;
 }
 export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
-  const { memo, isLoading } = useGetMemoById(id);
+  const { memo, status } = useGetMemoById(id);
   const { updateMemo } = useUpdateMemo();
   const { deleteMemo } = useDeleteMemo();
 
@@ -41,7 +41,7 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
   };
 
   useEffect(() => {
-    if (!isLoading && memo) {
+    if (status === 'success' && memo) {
       setMemoData({
         id: memo.id,
         title: memo.title,
@@ -49,7 +49,7 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
         category: memo.category,
       });
     }
-  }, [isLoading, memo]);
+  }, [status, memo]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMemoData(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -63,7 +63,6 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
     const result = await updateMemo(id, memoData);
     if (result.success) {
       console.log('메모가 성공적으로 업데이트되었습니다.');
-      router.push('/');
     } else {
       console.error('메모 업데이트 중 오류가 발생했습니다:', result.message);
       // TODO: 사용자에게 오류 메시지를 표시하는 로직 추가 필요 (ex: toast)
@@ -73,7 +72,9 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
   const handleClose = (e?: React.MouseEvent) => {
     e?.stopPropagation();
     onClose();
+    if (status !== 'success') return;
     handleUpdateMemo();
+    router.push('/');
   };
 
   // TODO: 로딩 스켈레톤 구현 필요
@@ -86,9 +87,13 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
       size="large"
       className="max-w-2xl relative sm:h-[70vh] h-[100vh]"
     >
-      {isLoading ? (
+      {status === 'loading' ? (
         <div className="flex items-center justify-center h-full">
           <p>Loading...</p>
+        </div>
+      ) : status === 'error' ? (
+        <div className="flex items-center justify-center h-full">
+          <p>메모를 불러오는 중 오류가 발생했습니다.</p>
         </div>
       ) : (
         <>

--- a/src/components/memo-editor/MemoUpdateModal.tsx
+++ b/src/components/memo-editor/MemoUpdateModal.tsx
@@ -1,9 +1,11 @@
 'use client';
 import AddButton from '@/components/common/AddButton';
 import CrossButton from '@/components/common/CrossButton';
+import DeleteButton from '@/components/common/DeleteButton';
 import InputField from '@/components/common/InputField';
 import MarkDownEditor from '@/components/MarkdownEditor';
 import { Modal } from '@/components/Modal';
+import useDeleteMemo from '@/hooks/useDeleteMemo';
 import useGetMemoById from '@/hooks/useGetMemoById';
 import useUpdateMemo from '@/hooks/useUpdateMemo';
 import { useRouter } from 'next/navigation';
@@ -16,6 +18,7 @@ interface MemoUpdateModalProps {
 export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
   const { memo, isLoading } = useGetMemoById(id);
   const { updateMemo } = useUpdateMemo();
+  const { deleteMemo } = useDeleteMemo();
 
   const [memoData, setMemoData] = useState({
     id,
@@ -25,6 +28,17 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
   });
 
   const router = useRouter();
+
+  const handleDeleteMemo = async () => {
+    const result = await deleteMemo(id);
+    if (result.success) {
+      console.log('메모가 성공적으로 삭제되었습니다.');
+      router.push('/');
+    } else {
+      console.error('메모 삭제 중 오류가 발생했습니다:', result.message);
+      // TODO: 사용자에게 오류 메시지를 표시하는 로직 추가 필요 (ex: toast)
+    }
+  };
 
   useEffect(() => {
     if (!isLoading && memo) {
@@ -78,6 +92,11 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
         </div>
       ) : (
         <>
+          <DeleteButton
+            onClick={handleDeleteMemo}
+            label="Delete memo"
+            className="absolute top-1 right-12"
+          />
           <div className="absolute top-1 right-1">
             <CrossButton onClick={handleClose} label="Close editor" />
           </div>

--- a/src/hooks/useDeleteMemo.ts
+++ b/src/hooks/useDeleteMemo.ts
@@ -1,0 +1,26 @@
+async function fetchDeleteMemo(id: string): Promise<{ success: boolean; message?: string }> {
+  try {
+    const response = await fetch(`/api/memos/${id}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) {
+      throw new Error('Failed to delete memo');
+    }
+    return { success: true, message: id };
+  } catch (error) {
+    console.error('Error deleting memo:', error);
+    if (error instanceof Error) {
+      return { success: false, message: error.message };
+    } else {
+      return { success: false, message: 'Unknown error occurred while deleting memo' };
+    }
+  }
+}
+
+export default function useDeleteMemo() {
+  const deleteMemo = async (id: string): Promise<{ success: boolean; message?: string }> => {
+    return fetchDeleteMemo(id);
+  };
+
+  return { deleteMemo };
+}

--- a/src/hooks/useGetMemoById.ts
+++ b/src/hooks/useGetMemoById.ts
@@ -24,17 +24,21 @@ const fetchMemoById = async (id: string): Promise<MemoProps> => {
 
 export default function useGetMemoById(id: string) {
   const [memo, setMemo] = useState<MemoProps | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error' | 'success'>('idle');
   useEffect(() => {
     const fetchData = async () => {
-      setIsLoading(true);
-      const fetchedMemo = await fetchMemoById(id);
-      setMemo(fetchedMemo);
-      setIsLoading(false);
+      setStatus('loading');
+      try {
+        const fetchedMemo = await fetchMemoById(id);
+        setMemo(fetchedMemo);
+        setStatus('success');
+      } catch (error) {
+        console.error('Error fetching memo:', error);
+        setStatus('error');
+      }
     };
     fetchData();
   }, [id]);
 
-  return { memo, isLoading };
+  return { memo, status };
 }

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 export const memoCardSchema = z.object({
   id: z.string(),
-  title: z.string().min(1, '제목은 필수입니다'),
-  content: z.string().min(1, '내용은 필수입니다'),
+  title: z.string(),
+  content: z.string(),
 });
 
 export const memoSchema = memoCardSchema.extend({


### PR DESCRIPTION
- MemoUpdateModal 컴포넌트에 메모 삭제 버튼 추가
- useDeleteMemo 훅을 사용하여 메모 삭제 기능 구현
- 삭제 후 toast 메시지로 사용자에게 성공/실패 알림 추가 예정

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 메모 수정 모달에 삭제 버튼이 추가되어 메모를 바로 삭제할 수 있습니다. 삭제 후 메인 화면으로 이동합니다.
	- 새로운 삭제 버튼 UI가 도입되어 직관적이고 접근성 높은 인터페이스를 제공합니다.
- **개선 사항**
	- 마크다운 에디터가 화면 크기에 따라 자동으로 편집 모드 또는 미리보기 모드로 전환되어 사용성이 향상되었습니다.
	- 메모 로딩 상태가 세분화되어 로딩, 성공, 오류 상태에 따른 UI 표시가 개선되었습니다.
- **버그 수정**
	- 메모 제목과 내용의 최소 글자 수 제한이 제거되어 빈 값 입력이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->