### PR TITLE
[feat] 토스트를 통한 메모 삭제 취소 기능 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-toastify": "^11.0.5",
-        "react-use": "^17.6.0",
         "remark-breaks": "^4.0.0",
         "tailwind-merge": "^3.3.0",
         "zod": "^3.25.30"
@@ -2421,12 +2420,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/js-cookie": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3245,12 +3238,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@xobotyi/scrollbar-width": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
-      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==",
-      "license": "MIT"
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4003,15 +3990,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4025,15 +4003,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-in-js-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
-      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
-      "license": "MIT",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.3"
       }
     },
     "node_modules/css-selector-parser": {
@@ -4051,19 +4020,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4326,15 +4282,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/error-stack-parser": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
-      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -5040,11 +4987,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
-    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -5060,12 +5002,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastest-stable-stringify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
-      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -5815,12 +5751,6 @@
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5869,15 +5799,6 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
-    },
-    "node_modules/inline-style-prefixer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
-      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
-      "license": "MIT",
-      "dependencies": {
-        "css-in-js-utils": "^3.1.0"
-      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6426,12 +6347,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7387,12 +7302,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "license": "CC0-1.0"
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8077,26 +7986,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nano-css": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
-      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
-      "license": "Unlicense",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "css-tree": "^1.1.2",
-        "csstype": "^3.1.2",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^7.0.1",
-        "rtl-css-js": "^1.16.1",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.3.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -8889,41 +8778,6 @@
         "react-dom": "^18 || ^19"
       }
     },
-    "node_modules/react-universal-interface": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-      "peerDependencies": {
-        "react": "*",
-        "tslib": "*"
-      }
-    },
-    "node_modules/react-use": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
-      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
-      "license": "Unlicense",
-      "dependencies": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.6.2",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -9313,12 +9167,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
-    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -9369,15 +9217,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rtl-css-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
-      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/run-parallel": {
@@ -9538,18 +9377,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/screenfull": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -9605,15 +9432,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-harmonic-interval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
-      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=6.9"
       }
     },
     "node_modules/set-proto": {
@@ -9787,6 +9605,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9827,51 +9646,6 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stack-generator": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
-      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
-      }
-    },
-    "node_modules/stackframe": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-      "license": "MIT"
-    },
-    "node_modules/stacktrace-gps": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
-      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.3.4"
-      }
-    },
-    "node_modules/stacktrace-gps/node_modules/source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stacktrace-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
-      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
-      "license": "MIT",
-      "dependencies": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
-      }
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -10104,12 +9878,6 @@
         }
       }
     },
-    "node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10233,15 +10001,6 @@
         }
       }
     },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
@@ -10300,12 +10059,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "license": "MIT"
-    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -10338,12 +10091,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-easing": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
-      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
-      "license": "Unlicense"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
+        "react-toastify": "^11.0.5",
         "react-use": "^17.6.0",
         "remark-breaks": "^4.0.0",
         "tailwind-merge": "^3.3.0",
@@ -8873,6 +8874,19 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-universal-interface": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint --fix",
     "type-check": "tsc --noEmit",
     "git-config": "git config --local include.path ../.gitconfig",
-    "prepare": "lefthook install"
+    "prepare": "lefthook install",
+    "depcheck": "npx depcheck"
   },
   "dependencies": {
     "@scalar/nextjs-api-reference": "^0.8.3",
@@ -24,7 +25,6 @@
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-toastify": "^11.0.5",
-    "react-use": "^17.6.0",
     "remark-breaks": "^4.0.0",
     "tailwind-merge": "^3.3.0",
     "zod": "^3.25.30"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
+    "react-toastify": "^11.0.5",
     "react-use": "^17.6.0",
     "remark-breaks": "^4.0.0",
     "tailwind-merge": "^3.3.0",

--- a/src/app/api/memos/restore/[id]/route.ts
+++ b/src/app/api/memos/restore/[id]/route.ts
@@ -1,0 +1,23 @@
+import { undoDeleteMemo } from '@/lib/services/memo.service';
+import { NextResponse } from 'next/server';
+
+interface Params {
+  id: string;
+}
+
+export async function POST(request: Request, { params }: { params: Promise<Params> }) {
+  try {
+    const { id } = await params;
+    const restoredMemo = await undoDeleteMemo(id);
+    return NextResponse.json({
+      success: true,
+      memo: restoredMemo,
+    });
+  } catch (error) {
+    console.error('메모 복원중 에러 발생:', error);
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: '메모 복원중 알 수 없는 오류 발생' }, { status: 500 });
+  }
+}

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,9 +1,9 @@
 'use client';
+import useWindowSize from '@/hooks/useWindowSize';
 import '@uiw/react-markdown-preview/markdown.css';
 import type { PreviewType } from '@uiw/react-md-editor';
-import '@uiw/react-md-editor/markdown-editor.css';
 import dynamic from 'next/dynamic';
-import { useWindowSize } from 'react-use';
+// import { useWindowSize } from 'react-use';
 
 const MDEditor = dynamic(() => import('@uiw/react-md-editor'), {
   ssr: false,

--- a/src/components/common/CrossButton.tsx
+++ b/src/components/common/CrossButton.tsx
@@ -11,7 +11,7 @@ export default function CrossButton({ onClick, label, className }: CrossButtonPr
   return (
     <button
       className={cn(
-        'p-2 rounded-full bg-gray-100/60 hover:bg-gray-200/70 transition-colors',
+        'p-1 rounded-full bg-gray-100/60 hover:bg-gray-200/70 transition-colors',
         className,
       )}
       onClick={onClick}

--- a/src/components/common/DeleteButton.tsx
+++ b/src/components/common/DeleteButton.tsx
@@ -12,7 +12,7 @@ interface DeleteButtonProps {
 export default function DeleteButton({ onClick, label, className }: DeleteButtonProps) {
   return (
     <button
-      className={cn('p-2 rounded-full hover:bg-red-200/70 transition-colors', className)}
+      className={cn('p-1 rounded-full hover:bg-red-200/70 transition-colors', className)}
       onClick={onClick}
       aria-label={label}
       title={label}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import Header from '@/components/layout/Header';
 import Sidebar from '@/components/layout/sidebar/Sidebar';
 import MemoCreateButton from '@/components/memo-editor/MemoCreateButton';
 import { useState } from 'react';
+import { ToastContainer } from 'react-toastify';
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -20,7 +21,10 @@ export default function MainLayout({ children }: MainLayoutProps) {
     <div className="flex flex-row min-h-screen relative">
       <div className="flex-1 flex flex-col min-h-screen w-full md:w-auto">
         <Header onToggleSidebar={toggleSidebar} isSidebarOpen={isSidebarOpen} />
-        <main className="flex-1 container mx-auto px-4 py-3 mt-16">{children}</main>
+        <main className="flex-1 container mx-auto px-4 py-3 mt-16">
+          {children}
+          <ToastContainer />
+        </main>
       </div>
       <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} className="md:static absolute" />
       <MemoCreateButton />

--- a/src/components/memo-editor/MemoUpdateModal.tsx
+++ b/src/components/memo-editor/MemoUpdateModal.tsx
@@ -5,12 +5,12 @@ import DeleteButton from '@/components/common/DeleteButton';
 import InputField from '@/components/common/InputField';
 import MarkDownEditor from '@/components/MarkdownEditor';
 import { Modal } from '@/components/Modal';
+import { showUndoDeleteToast } from '@/components/toast/showUndoDeleteToast';
 import useDeleteMemo from '@/hooks/useDeleteMemo';
 import useGetMemoById from '@/hooks/useGetMemoById';
 import useUpdateMemo from '@/hooks/useUpdateMemo';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-
 interface MemoUpdateModalProps {
   onClose: () => void;
   id: string;
@@ -34,6 +34,8 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
     if (result.success) {
       console.log('메모가 성공적으로 삭제되었습니다.');
       router.push('/');
+      onClose();
+      showUndoDeleteToast(id);
     } else {
       console.error('메모 삭제 중 오류가 발생했습니다:', result.message);
       // TODO: 사용자에게 오류 메시지를 표시하는 로직 추가 필요 (ex: toast)

--- a/src/components/memo-editor/MemoUpdateModal.tsx
+++ b/src/components/memo-editor/MemoUpdateModal.tsx
@@ -94,6 +94,9 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
       ) : status === 'error' ? (
         <div className="flex items-center justify-center h-full">
           <p>메모를 불러오는 중 오류가 발생했습니다.</p>
+          <div className="absolute top-1 right-1">
+            <CrossButton onClick={handleClose} label="Close editor" />
+          </div>
         </div>
       ) : (
         <>

--- a/src/components/memo/MemoCard.tsx
+++ b/src/components/memo/MemoCard.tsx
@@ -20,24 +20,26 @@ export default function MemoCard({ id, title, content }: MemoCardProps) {
   };
 
   return (
-    <div
-      onClick={handleOpenModal}
-      className="aspect-square border border-gray-300 rounded-lg p-4 overflow-hidden cursor-pointer"
-      role="button"
-      tabIndex={0}
-      onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          console.log(id);
-        }
-      }}
-    >
-      <div className="flex flex-col gap-1 overflow-y-hidden h-full">
-        <h1 className="font-semibold text-lg">{title}</h1>
-        <div className="prose prose-sm">
-          <ReactMarkdown remarkPlugins={[remarkBreaks]}>{content}</ReactMarkdown>
+    <>
+      <div
+        onClick={handleOpenModal}
+        className="aspect-square border border-gray-300 rounded-lg p-4 overflow-hidden cursor-pointer"
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            console.log(id);
+          }
+        }}
+      >
+        <div className="flex flex-col gap-1 overflow-y-hidden h-full">
+          <h1 className="font-semibold text-lg">{title}</h1>
+          <div className="prose prose-sm">
+            <ReactMarkdown remarkPlugins={[remarkBreaks]}>{content}</ReactMarkdown>
+          </div>
         </div>
-        {open && <MemoUpdateModal id={id} onClose={handleCloseModal} />}
       </div>
-    </div>
+      {open && <MemoUpdateModal id={id} onClose={handleCloseModal} />}
+    </>
   );
 }

--- a/src/components/toast/showUndoDeleteToast.tsx
+++ b/src/components/toast/showUndoDeleteToast.tsx
@@ -1,0 +1,50 @@
+import CrossButton from '@/components/common/CrossButton';
+import { toast } from 'react-toastify';
+
+interface SplitButtonsProps {
+  closeToast: () => void;
+  undo: () => void;
+}
+
+function MemoDeleteToast({ closeToast, undo }: SplitButtonsProps) {
+  return (
+    <div className="w-full">
+      <div className="flex items-center justify-between">
+        <span className="text-gray-800 text-sm">메모가 삭제되었습니다</span>
+        <button
+          className="text-black hover:bg-gray-100 rounded px-4 py-2 text-sm font-semibold transition"
+          onClick={undo}
+        >
+          삭제 취소
+        </button>
+        <CrossButton label="닫기" onClick={closeToast} />
+      </div>
+    </div>
+  );
+}
+
+/*
+ * 메모 삭제 후 토스트 알림을 표시하는 함수
+ * @param id - 삭제된 메모의 ID
+ */
+export const showUndoDeleteToast = (id: string) => {
+  toast(
+    () => (
+      <MemoDeleteToast
+        closeToast={() => toast.dismiss()}
+        undo={() => {
+          console.log(`Undo delete for memo ID: ${id}`);
+        }}
+      />
+    ),
+    {
+      closeButton: false,
+      position: 'bottom-left',
+      className: 'w-[400px] border border-gray-300 rounded-lg p-4 shadow-lg',
+      ariaLabel: '메모 삭제 알림',
+      pauseOnHover: false,
+      hideProgressBar: true,
+      autoClose: 3000,
+    },
+  );
+};

--- a/src/components/toast/showUndoDeleteToast.tsx
+++ b/src/components/toast/showUndoDeleteToast.tsx
@@ -1,19 +1,35 @@
 import CrossButton from '@/components/common/CrossButton';
+import useUndoDeleteMemo from '@/hooks/useUndoDeleMemo';
+import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 
 interface SplitButtonsProps {
   closeToast: () => void;
-  undo: () => void;
+  id: string;
 }
 
-function MemoDeleteToast({ closeToast, undo }: SplitButtonsProps) {
+function MemoDeleteToast({ closeToast, id }: SplitButtonsProps) {
+  const { undoDeleteMemo } = useUndoDeleteMemo(id);
+
+  const router = useRouter();
+
+  const handleUndo = async () => {
+    try {
+      await undoDeleteMemo();
+      closeToast();
+      router.push('/');
+    } catch (error) {
+      console.error('메모 복원 중 오류 발생:', error);
+    }
+  };
+
   return (
     <div className="w-full">
       <div className="flex items-center justify-between">
         <span className="text-gray-800 text-sm">메모가 삭제되었습니다</span>
         <button
           className="text-black hover:bg-gray-100 rounded px-4 py-2 text-sm font-semibold transition"
-          onClick={undo}
+          onClick={handleUndo}
         >
           삭제 취소
         </button>
@@ -28,23 +44,13 @@ function MemoDeleteToast({ closeToast, undo }: SplitButtonsProps) {
  * @param id - 삭제된 메모의 ID
  */
 export const showUndoDeleteToast = (id: string) => {
-  toast(
-    () => (
-      <MemoDeleteToast
-        closeToast={() => toast.dismiss()}
-        undo={() => {
-          console.log(`Undo delete for memo ID: ${id}`);
-        }}
-      />
-    ),
-    {
-      closeButton: false,
-      position: 'bottom-left',
-      className: 'w-[400px] border border-gray-300 rounded-lg p-4 shadow-lg',
-      ariaLabel: '메모 삭제 알림',
-      pauseOnHover: false,
-      hideProgressBar: true,
-      autoClose: 3000,
-    },
-  );
+  toast(() => <MemoDeleteToast closeToast={() => toast.dismiss()} id={id} />, {
+    closeButton: false,
+    position: 'bottom-left',
+    className: 'w-[400px] border border-gray-300 rounded-lg p-4 shadow-lg',
+    ariaLabel: '메모 삭제 알림',
+    pauseOnHover: false,
+    hideProgressBar: true,
+    autoClose: 3000,
+  });
 };

--- a/src/hooks/useUndoDeleMemo.ts
+++ b/src/hooks/useUndoDeleMemo.ts
@@ -9,7 +9,11 @@ const fetchUndoDeleteMemo = async (id: string) => {
     if (!response.ok) {
       throw new Error('메모 복원 실패');
     }
-    return await response.json();
+    const data = await response.json();
+    if (!data.success) {
+      throw new Error(data.error || '메모 복원 중 알 수 없는 오류 발생');
+    }
+    return data;
   } catch (error) {
     console.error('메모 복원 중 오류 발생:', error);
     throw error;

--- a/src/hooks/useUndoDeleMemo.ts
+++ b/src/hooks/useUndoDeleMemo.ts
@@ -1,0 +1,39 @@
+import type { MemoProps } from '@/types/memo';
+import { useState } from 'react';
+
+const fetchUndoDeleteMemo = async (id: string) => {
+  try {
+    const response = await fetch(`/api/memos/restore/${id}`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      throw new Error('메모 복원 실패');
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('메모 복원 중 오류 발생:', error);
+    throw error;
+  }
+};
+
+export default function useUndoDeleteMemo(id: string) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [memo, setMemo] = useState<MemoProps | null>(null);
+
+  const undoDeleteMemo = async () => {
+    setStatus('loading');
+    try {
+      const result = await fetchUndoDeleteMemo(id);
+      setMemo(result.memo);
+      setStatus('success');
+    } catch (err) {
+      if (err instanceof Error) {
+        setStatus('error');
+      } else {
+        setStatus('error');
+      }
+    }
+  };
+
+  return { status, memo, undoDeleteMemo };
+}

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export default function useWindowSize() {
+  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return windowSize;
+}

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
 
 export default function useWindowSize() {
-  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
+  const [windowSize, setWindowSize] = useState({
+    width: typeof window !== 'undefined' ? window.innerWidth : 0,
+    height: typeof window !== 'undefined' ? window.innerHeight : 0,
+  });
 
   useEffect(() => {
     const handleResize = () => {


### PR DESCRIPTION

### 삭제 취소 모달 구현
- showUndoDeleteToast 토스트에서 '삭제 취소' 버튼을 누르면 삭제가 취소되도록함.
- useUndoDeleteMemo 훅에서는 fetch를 통해 삭제를 취소함

### memo 복원 API 추가
- memos/restore/[id]/route.ts: 메모 복원 API 엔드포인트 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 메모 삭제 후 3초간 되돌리기(Undo) 토스트 알림이 표시됩니다.
	- 삭제된 메모를 복원하는 기능이 추가되었습니다.
	- 창 크기 변화를 감지하는 새로운 윈도우 사이즈 훅이 도입되었습니다.
- **버그 수정**
	- 삭제된 메모가 목록에 더 이상 표시되지 않습니다.
- **UI/UX 개선**
	- 삭제 및 닫기 버튼의 패딩이 줄어들어 인터페이스가 더 컴팩트해졌습니다.
	- 메모 편집 오류 시 닫기 버튼이 추가되어, 에러 상태에서도 쉽게 창을 닫을 수 있습니다.
	- 토스트 알림이 메인 레이아웃에 통합되어 알림 표시가 개선되었습니다.
	- 메모 삭제 시 모달이 자동으로 닫히고, 되돌리기 토스트가 즉시 표시됩니다.
- **기타**
	- 삭제는 실제 삭제가 아닌 소프트 딜리트 방식으로 변경되었습니다.
	- 외부 라이브러리 의존성 일부가 변경 및 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->