### PR TITLE
[fix] 삭제 토스트를 다크 테마 색상으로 수정함. 다른 버튼들 padding 사이즈 수정

### DIFF
--- a/src/app/api/memos/[id]/route.ts
+++ b/src/app/api/memos/[id]/route.ts
@@ -20,8 +20,8 @@ export async function GET(req: Request, { params }: { params: Promise<Params> })
   }
 }
 
-export async function DELETE(req: Request, { params }: { params: { id: string } }) {
-  const { id } = params;
+export async function DELETE(req: Request, { params }: { params: Promise<Params> }) {
+  const { id } = await params;
   try {
     const deletedId = await deleteMemo(id);
     return NextResponse.json(

--- a/src/components/common/CrossButton.tsx
+++ b/src/components/common/CrossButton.tsx
@@ -5,19 +5,33 @@ interface CrossButtonProps {
   onClick: (e?: React.MouseEvent<HTMLButtonElement>) => void;
   label: string;
   className?: string;
+  theme?: 'light' | 'dark';
+  iconSize?: 'small' | 'medium' | 'large';
 }
 
-export default function CrossButton({ onClick, label, className }: CrossButtonProps) {
+export default function CrossButton({
+  onClick,
+  label,
+  className,
+  theme = 'light',
+  iconSize = 'medium',
+}: CrossButtonProps) {
   return (
     <button
-      className={cn(
-        'p-1 rounded-full bg-gray-100/60 hover:bg-gray-200/70 transition-colors',
-        className,
-      )}
+      className={cn('p-2 rounded-full transition-colors cursor-pointer', className, {
+        'hover:bg-gray-700 text-gray-100': theme === 'dark',
+        'hover:bg-gray-200 text-gray-800': theme === 'light',
+      })}
       onClick={onClick}
       aria-label={label}
     >
-      <MdClose className="h-6 w-6" />
+      <MdClose
+        className={cn(
+          iconSize === 'small' && 'h-5 w-5',
+          iconSize === 'medium' && 'h-6 w-6',
+          iconSize === 'large' && 'h-8 w-8',
+        )}
+      />
     </button>
   );
 }

--- a/src/components/common/DeleteButton.tsx
+++ b/src/components/common/DeleteButton.tsx
@@ -12,7 +12,10 @@ interface DeleteButtonProps {
 export default function DeleteButton({ onClick, label, className }: DeleteButtonProps) {
   return (
     <button
-      className={cn('p-1 rounded-full hover:bg-red-200/70 transition-colors', className)}
+      className={cn(
+        'p-2 rounded-full hover:bg-red-200/70 transition-colors cursor-pointer',
+        className,
+      )}
       onClick={onClick}
       aria-label={label}
       title={label}

--- a/src/components/toast/showUndoDeleteToast.tsx
+++ b/src/components/toast/showUndoDeleteToast.tsx
@@ -24,16 +24,16 @@ function MemoDeleteToast({ closeToast, id }: SplitButtonsProps) {
   };
 
   return (
-    <div className="w-full">
-      <div className="flex items-center justify-between">
-        <span className="text-gray-800 text-sm">메모가 삭제되었습니다</span>
+    <div className="w-full flex items-center justify-between">
+      <span className="text-gray-100 text-sm">메모가 삭제되었습니다</span>
+      <div className="flex items-center gap-2">
         <button
-          className="text-black hover:bg-gray-100 rounded px-4 py-2 text-sm font-semibold transition"
+          className="text-blue-400 hover:bg-gray-700 rounded px-4 py-2 text-sm font-semibold transition cursor-pointer"
           onClick={handleUndo}
         >
           삭제 취소
         </button>
-        <CrossButton label="닫기" onClick={closeToast} />
+        <CrossButton label="닫기" onClick={closeToast} theme="dark" iconSize="small" />
       </div>
     </div>
   );
@@ -47,10 +47,14 @@ export const showUndoDeleteToast = (id: string) => {
   toast(() => <MemoDeleteToast closeToast={() => toast.dismiss()} id={id} />, {
     closeButton: false,
     position: 'bottom-left',
-    className: 'w-[400px] border border-gray-300 rounded-lg p-4 shadow-lg',
     ariaLabel: '메모 삭제 알림',
     pauseOnHover: false,
     hideProgressBar: true,
-    autoClose: 3000,
+    style: {
+      backgroundColor: 'black',
+      width: '440px',
+      boxShadow: '0 4px 16px rgba(0,0,0,0.25)',
+    },
+    autoClose: false,
   });
 };

--- a/src/components/toast/showUndoDeleteToast.tsx
+++ b/src/components/toast/showUndoDeleteToast.tsx
@@ -55,6 +55,5 @@ export const showUndoDeleteToast = (id: string) => {
       width: '440px',
       boxShadow: '0 4px 16px rgba(0,0,0,0.25)',
     },
-    autoClose: false,
   });
 };


### PR DESCRIPTION
- showUndoDeleteToast.tsx 파일을 수정하여 다크 테마에서 메모 삭제 알림이 잘 보이도록 다크 테마 스타일을 적용

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - CrossButton 컴포넌트에 테마(라이트/다크)와 아이콘 크기(스몰/미디엄/라지) 옵션이 추가되었습니다.

- **스타일**
  - CrossButton과 DeleteButton의 버튼 패딩이 증가하고, 커서가 포인터로 변경되었습니다.
  - CrossButton의 테마에 따라 버튼 색상과 아이콘 크기가 다르게 표시됩니다.
  - 삭제 취소 토스트의 레이아웃과 색상이 개선되고, 자동 닫힘이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->