### PR TITLE
fix: 새 카테고리를 가진 메모 생성 시 MemoSection이 닫혔던 현상 수정

### DIFF
--- a/src/components/memo/MemoSection.tsx
+++ b/src/components/memo/MemoSection.tsx
@@ -16,7 +16,7 @@ export default function MemoSection({ memos }: MemoListProps) {
   const toggleOpen = (category: string) => {
     setIsOpen(prev => ({
       ...prev,
-      [category]: !prev[category],
+      [category]: prev[category] === undefined ? false : !prev[category],
     }));
   };
 
@@ -31,12 +31,15 @@ export default function MemoSection({ memos }: MemoListProps) {
               <Link href={`/${category}`} className="font-medium inline-block">
                 {category}
               </Link>
-              <ToggleButton onClick={() => toggleOpen(category)} isOpen={isOpen[category]} />
+              <ToggleButton
+                onClick={() => toggleOpen(category)}
+                isOpen={isOpen[category] ?? true}
+              />
             </div>
             <Separator my={3} />
             <div
               className={`transition-all duration-300 ease-in-out overflow-hidden ${
-                isOpen[category] ? 'max-h-full' : 'max-h-0 opacity-0'
+                (isOpen[category] ?? true) ? 'max-h-full' : 'max-h-0 opacity-0'
               }`}
             >
               <MemoList memos={filteredMemos} />


### PR DESCRIPTION
## 📋 작업 세부 사항

새 카테고리를 가진 메모 생성 시 MemoSection이 닫혔던 현상 수정

## 🔧 변경 사항 요약

categories에 새 카테고리가 들어오면 이를 새로 담는데, 해당 카테고리의 isOpen에 대한 초기화가 이루어지지 않아 undefined로 담기고 있음 -> true가 아니라서 MemoSection이 안열림

useEffect를 써서 새로운 카테고리의 isOpen을 true로 바꿔면 쉽게 해결 가능하지만, 화면 깜빡임이 발생 

따라서, isOpen이 undefined에도 MemoSection이 열릴 수 있도록 수정함

<!-- ## 📸 스크린샷 (선택 사항) -->
![bug_isopen](https://github.com/user-attachments/assets/2ee745a2-8fe0-4488-b541-28b2eb515d12)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 메모 카테고리의 열림/닫힘 상태가 명확하지 않던 문제를 개선하여, 처음에는 항상 열림 상태로 표시되고, 토글 시 정상적으로 닫히도록 UI 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->