### PR TITLE
fix: 종속성 검사 작업을 pre-push 훅에서 제거

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,11 +5,11 @@
 #
 pre-push:
   jobs:
-    - name: packages audit
-      tags:
-        - frontend
-        - security
-      run: npm audit
+    # - name: packages audit
+    #   tags:
+    #     - frontend
+    #     - security
+    #   run: npm audit
 
     - name: type check
       run: npm run type-check


### PR DESCRIPTION
- @eslint/typescript 종속성에 대한 문제로 인해 pre-push 훅에서 종속성 검사 작업을 제거
- 이 작업은 배포 직전에 실행 되도록 수정할 예정입니다.

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - pre-push 시 실행되던 `npm audit` 패키지 보안 검사 작업이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->