### PR TITLE
feat: 카테고리 생성/수정 시 값 검증하는 오류 메시지 구현

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -34,7 +34,8 @@ export const fetchCreateCategory = async (category: { category: string }) => {
     if (!response.ok) {
       throw new Error('카테고리 생성에 실패했습니다.');
     }
-    return response.json();
+
+    console.log(`새 카테고리 생성! : ${category}`);
   } catch (error) {
     console.error('카테고리 생성 중 오류 발생:', error);
     throw new Error('카테고리 생성 중 오류가 발생했습니다.');

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -15,7 +15,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   const [isCreating, setIsCreating] = useState(false);
   const [newCategory, setNewCategory] = useState('');
   const [categoryStates, setCategoryStates] = useState<
-    { name: string; isEditing: boolean; isHovered: boolean; editValue: string }[]
+    { name: string; isEditing: boolean; isHovered: boolean; editValue: string; error?: string }[]
   >([]);
   const [isError, setIsError] = useState('');
 
@@ -26,6 +26,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
         isEditing: false,
         isHovered: false,
         editValue: '',
+        error: '',
       })),
     );
   }, [fetchedCategories]);
@@ -43,7 +44,6 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
       categoryStates.some(category => category.name.toLowerCase() === trimmedCategory.toLowerCase())
     ) {
       setIsError('이미 존재하는 카테고리입니다.');
-      //TODO: 하단에 에러 메시지가 뜨도록 개선 필요
       return;
     } else {
       setIsError('');
@@ -121,14 +121,21 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
       // isEditing이 true -> 데이터를 수정하는 로직
       const newCategoryName = target.editValue.trim();
       if (newCategoryName === '') {
-        console.error('카테고리 이름을 입력해주세요.');
+        setCategoryStates(prev =>
+          prev.map((state, i) =>
+            i === index ? { ...state, error: '카테고리 명을 입력해주세요.' } : state,
+          ),
+        );
         return;
       } else if (
         newCategoryName.toLowerCase() !== categoryName.toLowerCase() &&
         categoryStates.some(cat => cat.name.toLowerCase() === newCategoryName.toLowerCase())
       ) {
-        console.error('이미 존재하는 카테고리입니다.');
-        //TODO: 하단에 에러 메시지가 뜨도록 개선 필요
+        setCategoryStates(prev =>
+          prev.map((state, i) =>
+            i === index ? { ...state, error: '이미 존재하는 카테고리입니다.' } : state,
+          ),
+        );
         return;
       }
 
@@ -139,7 +146,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
         // 로컬 상태 업데이트: 이름 변경 & isEditing 종료
         setCategoryStates(prev =>
           prev.map((state, i) =>
-            i === index ? { ...state, name: target.editValue, isEditing: false } : state,
+            i === index ? { ...state, name: target.editValue, isEditing: false, error: '' } : state,
           ),
         );
 
@@ -263,13 +270,18 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
                   </div>
 
                   {category.isEditing ? (
-                    <input
-                      type="text"
-                      value={category.editValue}
-                      onChange={e => handleEditInputChange(idx, e.target.value)}
-                      onKeyDown={e => handleCategoryModifyKeyDown(e, category.name, idx)}
-                      className="w-[180px] border-b border-gray-300 focus:border-gray-500 focus:outline-none"
-                    />
+                    <div className="flex flex-col">
+                      <input
+                        type="text"
+                        value={category.editValue}
+                        onChange={e => handleEditInputChange(idx, e.target.value)}
+                        onKeyDown={e => handleCategoryModifyKeyDown(e, category.name, idx)}
+                        className="w-[180px] border-b border-gray-300 focus:border-gray-500 focus:outline-none"
+                      />
+                      {category.error && (
+                        <span className="text-xs text-red-600 pt-1 pb-1">{category.error}</span>
+                      )}
+                    </div>
                   ) : (
                     <span>{category.name}</span>
                   )}

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -32,7 +32,9 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   }, [fetchedCategories]);
 
   const handlePlusClick = () => {
-    setIsCreating(!isCreating);
+    setIsCreating(prev => !prev);
+    setIsError('');
+    setNewCategory('');
   };
 
   const handleCreateClick = async () => {
@@ -46,12 +48,16 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
       setIsError('이미 존재하는 카테고리입니다.');
       return;
     } else {
-      setIsError('');
-
       try {
         // 로컬 상태 업데이트
         setCategoryStates(prev => [
-          { name: trimmedCategory, isEditing: false, isHovered: false, editValue: trimmedCategory, error: '' },
+          {
+            name: trimmedCategory,
+            isEditing: false,
+            isHovered: false,
+            editValue: trimmedCategory,
+            error: '',
+          },
           ...prev,
         ]);
         // Create 상태 off & input창 비움

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -17,7 +17,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   const [categoryStates, setCategoryStates] = useState<
     { name: string; isEditing: boolean; isHovered: boolean; editValue: string; error: string }[]
   >([]);
-  const [isError, setIsError] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
 
   useEffect(() => {
     setCategoryStates(() =>
@@ -33,19 +33,19 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
 
   const handlePlusClick = () => {
     setIsCreating(prev => !prev);
-    setIsError('');
+    setErrorMsg('');
     setNewCategory('');
   };
 
   const handleCreateClick = async () => {
     const trimmedCategory = newCategory.trim();
     if (trimmedCategory === '') {
-      setIsError('카테고리 명을 입력해주세요.');
+      setErrorMsg('카테고리 명을 입력해주세요.');
       return;
     } else if (
       categoryStates.some(category => category.name.toLowerCase() === trimmedCategory.toLowerCase())
     ) {
-      setIsError('이미 존재하는 카테고리입니다.');
+      setErrorMsg('이미 존재하는 카테고리입니다.');
       return;
     } else {
       try {
@@ -253,7 +253,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
               </div>
             )}
           </div>
-          {isError && <span className="pl-8 text-red-600 text-sm">{isError}</span>}
+          {errorMsg && <span className="pl-8 text-red-600 text-sm">{errorMsg}</span>}
           <div className="overflow-y-auto pr-4">
             <ul>
               {categoryStates.map((category, idx) => (

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -45,8 +45,6 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
       //TODO: 하단에 에러 메시지가 뜨도록 개선 필요
       return;
     } else {
-      console.log('새 카테고리 생성:', trimmedCategory);
-
       try {
         // 로컬 상태 업데이트
         setCategoryStates(prev => [
@@ -57,8 +55,8 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
         setIsCreating(false);
         setNewCategory('');
 
-        const res = await fetchCreateCategory({ category: trimmedCategory });
-        console.log('카테고리 생성 성공!', res);
+        await fetchCreateCategory({ category: trimmedCategory });
+
         showToast({
           name: '카테고리',
           state: '생성',

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -17,6 +17,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   const [categoryStates, setCategoryStates] = useState<
     { name: string; isEditing: boolean; isHovered: boolean; editValue: string }[]
   >([]);
+  const [isError, setIsError] = useState('');
 
   useEffect(() => {
     setCategoryStates(() =>
@@ -36,15 +37,17 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   const handleCreateClick = async () => {
     const trimmedCategory = newCategory.trim();
     if (trimmedCategory === '') {
-      console.error('카테고리 이름을 입력해주세요.');
+      setIsError('카테고리 명을 입력해주세요.');
       return;
     } else if (
       categoryStates.some(category => category.name.toLowerCase() === trimmedCategory.toLowerCase())
     ) {
-      console.error('이미 존재하는 카테고리입니다.');
+      setIsError('이미 존재하는 카테고리입니다.');
       //TODO: 하단에 에러 메시지가 뜨도록 개선 필요
       return;
     } else {
+      setIsError('');
+
       try {
         // 로컬 상태 업데이트
         setCategoryStates(prev => [
@@ -237,6 +240,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
               </div>
             )}
           </div>
+          {isError && <span className="pl-8 text-red-600 text-sm">{isError}</span>}
           <div className="overflow-y-auto pr-4">
             <ul>
               {categoryStates.map((category, idx) => (

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -15,7 +15,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   const [isCreating, setIsCreating] = useState(false);
   const [newCategory, setNewCategory] = useState('');
   const [categoryStates, setCategoryStates] = useState<
-    { name: string; isEditing: boolean; isHovered: boolean; editValue: string; error?: string }[]
+    { name: string; isEditing: boolean; isHovered: boolean; editValue: string; error: string }[]
   >([]);
   const [isError, setIsError] = useState('');
 
@@ -51,7 +51,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
       try {
         // 로컬 상태 업데이트
         setCategoryStates(prev => [
-          { name: trimmedCategory, isEditing: false, isHovered: false, editValue: trimmedCategory },
+          { name: trimmedCategory, isEditing: false, isHovered: false, editValue: trimmedCategory, error: '' },
           ...prev,
         ]);
         // Create 상태 off & input창 비움

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -257,7 +257,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           <div className="overflow-y-auto pr-4">
             <ul>
               {categoryStates.map((category, idx) => (
-                <li key={`${category}-${idx}`} className="flex h-[48px] -mx-4 px-4 py-3">
+                <li key={`${category.name}-${idx}`} className="flex h-[48px] -mx-4 px-4 py-3">
                   <div
                     className={`flex items-center justify-center w-[24px] h-[24px] mr-2 rounded-2xl ${'hover:bg-gray-200 cursor-pointer'}`}
                     onMouseEnter={() => handleMouseEnter(idx)}


### PR DESCRIPTION
## 📋 작업 세부 사항

- 카테고리 생성/수정 시 값 검증하는 오류 메시지 구현
- 생성/수정 관련 로직 일부 수정

## 🔧 변경 사항 요약

### 생성 시
- isError라는 변수를 추가하여 오류 메시지 관리
- 켜고 닫을 때마다 이전 입력 값 초기화
![cat_error-message1](https://github.com/user-attachments/assets/32ad6aac-26ce-48d3-8ea0-938303d07b0f)

### 수정 시
- categoryStates에 error 라는 프로퍼티를 추가하여 오류 메시지 관리
- 켜고 닫을 때마다 이전 입력 값 초기화
![cat_error-message2](https://github.com/user-attachments/assets/2d3bca1d-2dbd-4556-8340-da0c204dbe8e)

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 카테고리 생성 및 수정 시 발생하는 입력 오류(빈 값, 중복 이름 등)에 대해 사용자에게 에러 메시지가 화면에 표시되도록 개선되었습니다.
  - 각 카테고리별로 개별 에러 메시지가 입력란 아래에 표시되며, 새 카테고리 생성 시에도 에러 메시지가 별도로 안내됩니다.
  - 카테고리 생성 시 콘솔 로그 대신 사용자에게 생성 메시지가 출력됩니다.

- **스타일**
  - 카테고리 리스트의 키가 안정적으로 관리되어 UI 렌더링이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->