### PR TITLE
fix: MemoUpdateModal 데이터 패칭중 메모 업데이트 방지

### DIFF
--- a/src/components/memo-editor/MemoUpdateModal.tsx
+++ b/src/components/memo-editor/MemoUpdateModal.tsx
@@ -110,6 +110,9 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
           >
             다시 시도
           </button>
+          <div className="absolute top-1 right-1">
+            <CrossButton onClick={handleClose} label="Close editor" />
+          </div>
         </div>
       ) : isLoading || isFetching ? (
         <MemoEditorSkeleton />

--- a/src/hooks/useGetMemoById.ts
+++ b/src/hooks/useGetMemoById.ts
@@ -24,12 +24,12 @@ const fetchMemoById = async (id: string): Promise<MemoProps> => {
 };
 
 export default function useGetMemoById(id: string) {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, isFetching } = useQuery({
     queryKey: queryKeys.memo.detail(id),
     queryFn: () => fetchMemoById(id),
     staleTime: 1000 * 60 * 5,
     retry: 0,
   });
 
-  return { data, isLoading, isError };
+  return { data, isLoading, isError, isFetching };
 }

--- a/src/hooks/useUpdateMemo.ts
+++ b/src/hooks/useUpdateMemo.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 async function fetchUpdateMemo(
   id: string,
-  memo: Omit<MemoProps, 'id' | 'createdAt'>,
+  memo: Omit<MemoProps, 'createdAt'>,
 ): Promise<{ success: boolean; message: string }> {
   try {
     const response = await fetch(`/api/memos/${id}`, {
@@ -33,7 +33,7 @@ export default function useUpdateMemo() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (params: { id: string; memo: Omit<MemoProps, 'id' | 'createdAt'> }) =>
+    mutationFn: (params: { id: string; memo: Omit<MemoProps, 'createdAt'> }) =>
       fetchUpdateMemo(params.id, params.memo),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.memo.detail(variables.id) });


### PR DESCRIPTION
- isFetching 상태에서 메모 업데이트 시도 방지
- useGetMemoById 타입 수정

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 메모 수정 모달에서 로딩, 에러 및 추가적인 데이터 fetching 상태 처리가 개선되어, 데이터가 완전히 불러와지기 전에는 수정 또는 닫기 동작이 제한됩니다.

- **리팩터**
  - 메모 수정 시 입력 필드와 미리보기 영역이 로컬 편집 내용과 서버 데이터를 병합하여 더 안정적으로 최신 상태를 반영합니다.
  - 내부 데이터 동기화 방식이 `useMemo` 기반으로 변경되어 상태 관리가 더 선언적이고 효율적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->