### PR TITLE
fix: 로그인 버튼이 사이드바 버튼과 겹쳐지는 현상 수정  #87

### DIFF
--- a/src/components/auth/authSection.tsx
+++ b/src/components/auth/authSection.tsx
@@ -9,7 +9,7 @@ export default function AuthSection({ openSignIn }: { openSignIn: () => void }) 
 
   if (isAuthenticated) {
     return (
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-4">
         <UserProfile />
         <LogoutButton />
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,6 +29,7 @@ export default function Header({ onToggleSidebar, isSidebarOpen }: HeaderProps) 
           </div>
           <div className="flex items-center justify-end w-1/4 gap-3">
             <AuthSection openSignIn={openSignIn} />
+            <div className="w-10"></div>
             <ToggleSidebarButton onToggle={onToggleSidebar} isOpen={!isSidebarOpen} />
           </div>
         </div>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -26,7 +26,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
           <ToastContainer />
         </main>
       </div>
-      <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} className="md:static absolute" />
+      <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />
       <MemoCreateButton />
     </div>
   );

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -7,22 +7,18 @@ import CategoryItem from './CategoryItem';
 interface SidebarProps {
   isOpen: boolean;
   onToggle: () => void;
-  className?: string;
 }
 
-export default function Sidebar({ isOpen, onToggle, className = '' }: SidebarProps) {
-  const sidebar_px = 4;
-  const sidebar_my = 2;
-
+export default function Sidebar({ isOpen, onToggle }: SidebarProps) {
   return (
     <aside
-      className={`top-0 right-0 w-64 min-h-screen bg-gray-100 overflow-y-auto z-11 ${isOpen ? 'block' : 'hidden'} ${className}`}
+      className={`fixed top-0 right-0 w-64 min-h-screen bg-gray-100 overflow-y-auto z-11 ${isOpen ? 'block' : 'hidden'}`}
     >
       <div className="flex items-center justify-between px-4 pt-3 pb-1">
         <h2 className="font-bold text-lg translate-y-[5px]">Categories</h2>
         <ToggleSidebarButton onToggle={onToggle} isOpen={isOpen} />
       </div>
-      <Separator px={sidebar_px} my={sidebar_my} />
+      <Separator px={4} my={2} />
       <ul className="">
         {categories.map((category, index) => (
           <CategoryItem


### PR DESCRIPTION
- 사이드바 버튼과 로그인 버튼 사이에 여백을 추가하여 겹침 현상을 해결

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 인증된 사용자 프로필과 로그아웃 버튼 사이의 간격이 넓어졌습니다.
  - 헤더에서 인증 섹션과 사이드바 토글 버튼 사이에 여유 공간이 추가되어 레이아웃이 개선되었습니다.
  - 사이드바 컴포넌트의 위치와 스타일이 고정되어 일관된 레이아웃을 제공합니다.
  - 메인 레이아웃에서 사이드바의 위치 관련 클래스가 제거되어 스타일이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->