### PR TITLE
refactor: isOpen을 개별적으로 관리하는 MemoSection의 하위컴포넌트  MemoEachSection 생성

### DIFF
--- a/src/components/memo/MemoEachSection.tsx
+++ b/src/components/memo/MemoEachSection.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import MemoList from './MemoList';
+import Link from 'next/link';
+import Separator from '@/components/common/Separator';
+import ToggleButton from '@/components/common/ToggleButton';
+import { useState } from 'react';
+import type { MemoListProps } from '@/types/memo';
+
+interface MemoEachSectionProps {
+  category: string;
+  memos: MemoListProps['memos'];
+}
+
+export default function MemoEachSection({ category, memos }: MemoEachSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const toggleOpen = () => {
+    setIsOpen(prev => !prev);
+  };
+
+  return (
+    <div className="mb-6">
+      <div className="flex justify-between">
+        <Link href={`/${category}`} className="font-medium inline-block">
+          {category}
+        </Link>
+        <ToggleButton onClick={toggleOpen} isOpen={isOpen} />
+      </div>
+      <Separator my={3} />
+      <div
+        className={`transition-all duration-300 ease-in-out overflow-hidden ${
+          isOpen ? 'max-h-full' : 'max-h-0 opacity-0'
+        }`}
+      >
+        <MemoList memos={memos} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/memo/MemoEachSection.tsx
+++ b/src/components/memo/MemoEachSection.tsx
@@ -22,7 +22,7 @@ export default function MemoEachSection({ category, memos }: MemoEachSectionProp
   return (
     <div className="mb-6">
       <div className="flex justify-between">
-        <Link href={`/${category}`} className="font-medium inline-block">
+        <Link href={`/${encodeURIComponent(category)}`} className="font-medium inline-block">
           {category}
         </Link>
         <ToggleButton onClick={toggleOpen} isOpen={isOpen} />

--- a/src/components/memo/MemoSection.tsx
+++ b/src/components/memo/MemoSection.tsx
@@ -1,52 +1,20 @@
 'use client';
 
-import MemoList from './MemoList';
-import Link from 'next/link';
-import Separator from '@/components/common/Separator';
-import ToggleButton from '@/components/common/ToggleButton';
-import { useState } from 'react';
+import MemoEachSection from './MemoEachSection';
 import type { MemoListProps } from '@/types/memo';
 
 export default function MemoSection({ memos }: MemoListProps) {
   const categories = Array.from(new Set(memos.map(memo => memo.category)));
-  const [isOpen, setIsOpen] = useState<Record<string, boolean>>(
-    Object.fromEntries(categories.map(category => [category, true])),
-  );
-
-  const toggleOpen = (category: string) => {
-    setIsOpen(prev => ({
-      ...prev,
-      [category]: prev[category] === undefined ? false : !prev[category],
-    }));
-  };
+  const memosByCategory = categories.reduce<Record<string, typeof memos>>((acc, category) => {
+    acc[category] = memos.filter(memo => memo.category === category);
+    return acc;
+  }, {});
 
   return (
     <div>
-      {categories.map(category => {
-        const filteredMemos = memos.filter(memo => memo.category === category);
-
-        return (
-          <div key={category} className="mb-6">
-            <div className="flex justify-between">
-              <Link href={`/${category}`} className="font-medium inline-block">
-                {category}
-              </Link>
-              <ToggleButton
-                onClick={() => toggleOpen(category)}
-                isOpen={isOpen[category] ?? true}
-              />
-            </div>
-            <Separator my={3} />
-            <div
-              className={`transition-all duration-300 ease-in-out overflow-hidden ${
-                (isOpen[category] ?? true) ? 'max-h-full' : 'max-h-0 opacity-0'
-              }`}
-            >
-              <MemoList memos={filteredMemos} />
-            </div>
-          </div>
-        );
-      })}
+      {categories.map(category => (
+        <MemoEachSection key={category} category={category} memos={memosByCategory[category]} />
+      ))}
     </div>
   );
 }

--- a/src/components/memo/MemoSection.tsx
+++ b/src/components/memo/MemoSection.tsx
@@ -1,14 +1,18 @@
 'use client';
 
+import { useMemo } from 'react';
 import MemoEachSection from './MemoEachSection';
 import type { MemoListProps } from '@/types/memo';
 
 export default function MemoSection({ memos }: MemoListProps) {
-  const categories = Array.from(new Set(memos.map(memo => memo.category)));
-  const memosByCategory = categories.reduce<Record<string, typeof memos>>((acc, category) => {
-    acc[category] = memos.filter(memo => memo.category === category);
-    return acc;
-  }, {});
+  const { categories, memosByCategory } = useMemo(() => {
+    const categories = Array.from(new Set(memos.map(memo => memo.category)));
+    const memosByCategory = categories.reduce<Record<string, typeof memos>>((acc, cur) => {
+      acc[cur] = memos.filter(m => m.category === cur);
+      return acc;
+    }, {});
+    return { categories, memosByCategory };
+  }, [memos]);
 
   return (
     <div>


### PR DESCRIPTION
## 📋 작업 세부 사항
특정 카테고리의 isOpen을 변경하면 전체 MemoSection이 리렌더링되어 불필요한 트래픽이 증가했음.
-> isOpen을 카테고리마다 개별적으로 관리하는 하위컴포넌트  MemoEachSection 생성

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 카테고리별 메모를 펼치기/접기 할 수 있는 섹션 UI가 추가되었습니다.

- **리팩터**
  - 메모 목록의 카테고리별 렌더링 및 토글 기능이 별도의 컴포넌트로 분리되어 코드 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->