### PR TITLE
fix: auth-middleware params 타입 수정

### DIFF
--- a/src/app/api/categories/[categoryName]/route.ts
+++ b/src/app/api/categories/[categoryName]/route.ts
@@ -10,87 +10,79 @@ import { removeCategoryAndUpdateMemos } from '@/lib/services/memo.service';
 import { validateCategoryName } from '@/utils/validateCategoryName';
 import { type NextRequest, NextResponse } from 'next/server';
 
-interface CategoryParams {
-  categoryName: string;
-}
+export const PUT = withAuth(async (req: NextRequest, { userId, params }) => {
+  try {
+    const { categoryName } = await params!;
+    const body = await req.json();
+    const { newName } = body;
 
-export const PUT = withAuth<Promise<CategoryParams>>(
-  async (req: NextRequest, { userId, params }) => {
-    try {
-      const { categoryName } = await params!;
-      const body = await req.json();
-      const { newName } = body;
-
-      const existingCategoryId = await getCategoryIdByName(categoryName, userId);
-      if (!existingCategoryId) {
-        return NextResponse.json({ error: '해당 카테고리를 찾을 수 없습니다.' }, { status: 404 });
-      }
-
-      if (!validateCategoryName(newName) || typeof newName !== 'string') {
-        return NextResponse.json({ error: '유효하지 않은 카테고리 이름입니다.' }, { status: 400 });
-      }
-
-      if ((await isCategoryExists(newName, userId)) && categoryName !== newName) {
-        return NextResponse.json({ error: '이미 존재하는 카테고리 이름입니다.' }, { status: 400 });
-      }
-
-      await updateCategoryName(existingCategoryId, newName, userId);
-
-      return NextResponse.json(
-        { category: newName, message: '카테고리가 성공적으로 업데이트되었습니다.' },
-        { status: 200 },
-      );
-    } catch (error) {
-      console.error('Error updating category:', error);
-      if (error instanceof Error) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
-      }
-      return NextResponse.json({ error: '카테고리 업데이트에 실패했습니다.' }, { status: 500 });
+    const existingCategoryId = await getCategoryIdByName(categoryName, userId);
+    if (!existingCategoryId) {
+      return NextResponse.json({ error: '해당 카테고리를 찾을 수 없습니다.' }, { status: 404 });
     }
-  },
-);
-export const DELETE = withAuth<Promise<CategoryParams>>(
-  async (_req: NextRequest, { userId, params }) => {
-    try {
-      const { categoryName } = await params!;
 
-      const existingCategoryId = await getCategoryIdByName(categoryName, userId);
-      if (!existingCategoryId) {
-        return NextResponse.json({ error: '해당 카테고리를 찾을 수 없습니다.' }, { status: 404 });
-      }
-
-      if (categoryName.toLowerCase() === 'others') {
-        return NextResponse.json(
-          { error: "'others' 카테고리는 삭제할 수 없습니다." },
-          { status: 400 },
-        );
-      }
-
-      const othersId = await createCategoryIfNotExists('others', userId);
-      if (!othersId) {
-        return NextResponse.json(
-          { error: "'others' 카테고리를 찾거나 생성할 수 없습니다." },
-          { status: 500 },
-        );
-      }
-
-      await removeCategoryAndUpdateMemos(existingCategoryId, othersId, userId);
-
-      await deleteCategory(existingCategoryId, userId);
-
-      return NextResponse.json(
-        {
-          message:
-            "카테고리가 성공적으로 삭제되었습니다. 관련 메모는 'others' 카테고리로 이동되었습니다.",
-        },
-        { status: 200 },
-      );
-    } catch (error) {
-      console.error('Error deleting category:', error);
-      if (error instanceof Error) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
-      }
-      return NextResponse.json({ error: '카테고리 삭제에 실패했습니다.' }, { status: 500 });
+    if (!validateCategoryName(newName) || typeof newName !== 'string') {
+      return NextResponse.json({ error: '유효하지 않은 카테고리 이름입니다.' }, { status: 400 });
     }
-  },
-);
+
+    if ((await isCategoryExists(newName, userId)) && categoryName !== newName) {
+      return NextResponse.json({ error: '이미 존재하는 카테고리 이름입니다.' }, { status: 400 });
+    }
+
+    await updateCategoryName(existingCategoryId, newName, userId);
+
+    return NextResponse.json(
+      { category: newName, message: '카테고리가 성공적으로 업데이트되었습니다.' },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('Error updating category:', error);
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: '카테고리 업데이트에 실패했습니다.' }, { status: 500 });
+  }
+});
+export const DELETE = withAuth(async (_req: NextRequest, { userId, params }) => {
+  try {
+    const { categoryName } = await params!;
+
+    const existingCategoryId = await getCategoryIdByName(categoryName, userId);
+    if (!existingCategoryId) {
+      return NextResponse.json({ error: '해당 카테고리를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    if (categoryName.toLowerCase() === 'others') {
+      return NextResponse.json(
+        { error: "'others' 카테고리는 삭제할 수 없습니다." },
+        { status: 400 },
+      );
+    }
+
+    const othersId = await createCategoryIfNotExists('others', userId);
+    if (!othersId) {
+      return NextResponse.json(
+        { error: "'others' 카테고리를 찾거나 생성할 수 없습니다." },
+        { status: 500 },
+      );
+    }
+
+    await removeCategoryAndUpdateMemos(existingCategoryId, othersId, userId);
+
+    await deleteCategory(existingCategoryId, userId);
+
+    return NextResponse.json(
+      {
+        message:
+          "카테고리가 성공적으로 삭제되었습니다. 관련 메모는 'others' 카테고리로 이동되었습니다.",
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('Error deleting category:', error);
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: '카테고리 삭제에 실패했습니다.' }, { status: 500 });
+  }
+});

--- a/src/app/api/memos/[id]/route.ts
+++ b/src/app/api/memos/[id]/route.ts
@@ -2,11 +2,7 @@ import { withAuth } from '@/lib/auth-middleware';
 import { deleteMemo, getMemoById, updateMemo } from '@/lib/services/memo.service';
 import { type NextRequest, NextResponse } from 'next/server';
 
-interface MemoParams {
-  id: string;
-}
-
-export const GET = withAuth<Promise<MemoParams>>(async (req: NextRequest, { userId, params }) => {
+export const GET = withAuth(async (req: NextRequest, { userId, params }) => {
   try {
     const { id } = await params!;
 
@@ -28,7 +24,7 @@ export const GET = withAuth<Promise<MemoParams>>(async (req: NextRequest, { user
 });
 
 // PUT /api/memos/[id]
-export const PUT = withAuth<Promise<MemoParams>>(async (req: NextRequest, { userId, params }) => {
+export const PUT = withAuth(async (req: NextRequest, { userId, params }) => {
   try {
     const { id } = await params!;
     const body = await req.json();
@@ -53,21 +49,19 @@ export const PUT = withAuth<Promise<MemoParams>>(async (req: NextRequest, { user
 });
 
 // DELETE /api/memos/[id]
-export const DELETE = withAuth<Promise<MemoParams>>(
-  async (req: NextRequest, { userId, params }) => {
-    try {
-      const { id } = await params!;
+export const DELETE = withAuth(async (req: NextRequest, { userId, params }) => {
+  try {
+    const { id } = await params!;
 
-      if (!id) {
-        return NextResponse.json({ error: 'Memo ID is required' }, { status: 400 });
-      }
-
-      await deleteMemo(id, userId);
-
-      return NextResponse.json({ success: true });
-    } catch (error) {
-      console.error('Error deleting memo:', error);
-      return NextResponse.json({ error: 'Failed to delete memo' }, { status: 500 });
+    if (!id) {
+      return NextResponse.json({ error: 'Memo ID is required' }, { status: 400 });
     }
-  },
-);
+
+    await deleteMemo(id, userId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting memo:', error);
+    return NextResponse.json({ error: 'Failed to delete memo' }, { status: 500 });
+  }
+});

--- a/src/app/api/memos/restore/[id]/route.ts
+++ b/src/app/api/memos/restore/[id]/route.ts
@@ -2,25 +2,19 @@ import { withAuth } from '@/lib/auth-middleware';
 import { undoDeleteMemo } from '@/lib/services/memo.service';
 import { type NextRequest, NextResponse } from 'next/server';
 
-interface RestoreMemoParams {
-  id: string;
-}
-
-export const POST = withAuth<Promise<RestoreMemoParams>>(
-  async (req: NextRequest, { userId, params }) => {
-    try {
-      const { id } = await params!;
-      const restoredMemo = await undoDeleteMemo(id, userId);
-      return NextResponse.json({
-        success: true,
-        memo: restoredMemo,
-      });
-    } catch (error) {
-      console.error('메모 복원중 에러 발생:', error);
-      if (error instanceof Error) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
-      }
-      return NextResponse.json({ error: '메모 복원중 알 수 없는 오류 발생' }, { status: 500 });
+export const POST = withAuth(async (req: NextRequest, { userId, params }) => {
+  try {
+    const { id } = await params!;
+    const restoredMemo = await undoDeleteMemo(id, userId);
+    return NextResponse.json({
+      success: true,
+      memo: restoredMemo,
+    });
+  } catch (error) {
+    console.error('메모 복원중 에러 발생:', error);
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
-  },
-);
+    return NextResponse.json({ error: '메모 복원중 알 수 없는 오류 발생' }, { status: 500 });
+  }
+});

--- a/src/lib/auth-middleware.ts
+++ b/src/lib/auth-middleware.ts
@@ -1,10 +1,17 @@
 import { auth } from '@/auth';
 import { type NextRequest, NextResponse } from 'next/server';
 
-export function withAuth<T = Record<string, string>>(
-  handler: (req: NextRequest, context: { userId: string; params?: T }) => Promise<Response>,
-) {
-  return async (req: NextRequest, routeContext?: { params: T }) => {
+type RouteContext = {
+  params: Promise<Record<string, string>>;
+};
+
+export function withAuth(
+  handler: (
+    req: NextRequest,
+    context: { userId: string; params: Promise<Record<string, string>> },
+  ) => Promise<Response>,
+): (req: NextRequest, context: RouteContext) => Promise<Response> {
+  return async (req, context) => {
     const session = await auth();
 
     if (!session?.user?.id) {
@@ -13,7 +20,7 @@ export function withAuth<T = Record<string, string>>(
 
     return handler(req, {
       userId: session.user.id,
-      params: routeContext?.params,
+      params: context.params,
     });
   };
 }


### PR DESCRIPTION
- Nextjs App 라우터에서는 parqams가 Promise로 반환되므로, auth-middleware에서 params 타입을 Promise<Record<string, string>>로 수정
- route.ts 파일에서 withAuth 함수 사용 시 params를 Promise로 처리하도록 수정

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
  - 인증 미들웨어와 API 핸들러에서 불필요한 타입 선언 및 제네릭을 제거하여 코드 구조를 간소화했습니다.
  - 에러 처리 방식을 통일하고, 일부 핸들러에서 에러 구분 및 로깅을 개선했습니다.

- **버그 수정**
  - 카테고리 및 메모 관련 API에서 일관된 에러 응답 및 상태 코드 반환을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->