### PR TITLE
fix: 카테고리 수정/삭제 시 메모 캐시도 초기화되도록 변경

### DIFF
--- a/src/hooks/useDeleteCategory.ts
+++ b/src/hooks/useDeleteCategory.ts
@@ -1,3 +1,4 @@
+import { queryKeys } from '@/lib/queryKeys';
 import type { CategoryItem } from '@/types/category';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -44,6 +45,7 @@ export default function useDeleteCategory() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.memo.lists()});
     },
   });
 

--- a/src/hooks/useModifyCategory.ts
+++ b/src/hooks/useModifyCategory.ts
@@ -1,3 +1,4 @@
+import { queryKeys } from '@/lib/queryKeys';
 import type { CategoryItem } from '@/types/category';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -40,14 +41,13 @@ export default function useModifyCategory() {
       await queryClient.cancelQueries({ queryKey: ['categories'] });
 
       const prev = queryClient.getQueryData<CategoryItem[]>(['categories']);
-
       queryClient.setQueryData<CategoryItem[]>(['categories'], old =>
         old?.map(category =>
           category.name === categoryName ? { ...category, name: newCategoryName } : category,
         ),
       );
 
-      return { prev };
+      return { prev, categoryName };
     },
     onError: (_err, _variables, context) => {
       if (context?.prev) {
@@ -56,6 +56,7 @@ export default function useModifyCategory() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['categories'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.memo.lists() });
     },
   });
 


### PR DESCRIPTION
## 📋 작업 세부 사항

변경된 카테고리에 속한 메모 쿼리를 invalidate하여 효율적인 캐시 갱신 처리

## 🔧 변경 사항 요약

삭제/수정 로직에 `queryClient.invalidateQueries({ queryKey: queryKeys.memo.lists()});` 추가




