### PR TITLE
fix: useDeleteMemo 쿼리 캐시 제거 로직 수정

### DIFF
--- a/src/hooks/useDeleteMemo.ts
+++ b/src/hooks/useDeleteMemo.ts
@@ -31,15 +31,17 @@ export default function useDeleteMemo() {
       const previousMemo = queryClient.getQueryData(queryKeys.memo.detail(id));
       const previousMemos = queryClient.getQueryData(queryKeys.memo.lists());
 
-      if (!previousMemo || !previousMemos) return { previousMemo, previousMemos };
-
-      queryClient.setQueryData<MemoProps[]>(queryKeys.memo.lists(), old => {
-        if (!old) return old;
-        return old.filter(memo => memo.id !== id);
-      });
-      queryClient.removeQueries({
-        queryKey: queryKeys.memo.detail(id),
-      });
+      if (previousMemo) {
+        queryClient.removeQueries({
+          queryKey: queryKeys.memo.detail(id),
+        });
+      }
+      if (previousMemos) {
+        queryClient.setQueryData<MemoProps[]>(queryKeys.memo.lists(), old => {
+          if (!old) return old;
+          return old.filter(memo => memo.id !== id);
+        });
+      }
       return { previousMemo, previousMemos };
     },
     onError: (_error, id, context) => {

--- a/src/hooks/useDeleteMemo.ts
+++ b/src/hooks/useDeleteMemo.ts
@@ -34,6 +34,7 @@ export default function useDeleteMemo() {
       if (previousMemo) {
         queryClient.removeQueries({
           queryKey: queryKeys.memo.detail(id),
+          exact: true,
         });
       }
       if (previousMemos) {


### PR DESCRIPTION
- 이전 메모가 존재할 때만 detail 쿼리 제거
- 이전 메모 리스트가 존재할 때만 리스트 쿼리 제거

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 메모 삭제 시 캐시 업데이트 로직이 개선되어, 일부 캐시가 없더라도 남아있는 캐시에 대해 정상적으로 업데이트가 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->