### PR TITLE
fix: CategoryModal에 others가 렌더링되지 않도록 필터링

### DIFF
--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -26,13 +26,15 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
 
   useEffect(() => {
     setCategoryStates(() =>
-      fetchedCategories.map(category => ({
-        name: category.name,
-        isEditing: false,
-        isHovered: false,
-        editValue: '',
-        error: '',
-      })),
+      fetchedCategories
+        .filter(category => category.name !== 'others')
+        .map(category => ({
+          name: category.name,
+          isEditing: false,
+          isHovered: false,
+          editValue: '',
+          error: '',
+        })),
     );
   }, [fetchedCategories]);
 
@@ -156,9 +158,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
 
       // 로컬 상태만 수정(isEditing / error)
       setCategoryStates(prev =>
-        prev.map((state, i) =>
-          i === index ? { ...state, isEditing: false, error: '' } : state,
-        ),
+        prev.map((state, i) => (i === index ? { ...state, isEditing: false, error: '' } : state)),
       );
 
       fetchModifyCategory(

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -23,8 +23,8 @@ export default function useCategories() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['categories'],
     queryFn: fetchCategories,
+    initialData: [],
   });
-  const categories = useMemo(() => (data ? data : []), [data]);
 
-  return { categories, isLoading, isError };
+  return { categories: data, isLoading, isError };
 }

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,6 +1,5 @@
 import type { CategoryItem } from '@/types/category';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
 
 const fetchCategories = async (): Promise<CategoryItem[]> => {
   try {


### PR DESCRIPTION
## 📋 작업 세부 사항

CategoryModal에 others가 렌더링되지 않도록 필터링

## 🔧 변경 사항 요약

fetchedCategories에 `.filter(category => category.name !== 'others')`라는 조건을 추가하여 'others'를 필터링

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - "others"라는 이름의 카테고리가 카테고리 목록에서 제외되어 표시되지 않도록 개선되었습니다.

- **스타일**
  - 일부 내부 코드 포맷이 간결하게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->