### PR TITLE
fix: 메모 조회 API에 검색 및 필터링 기능 추가

### DIFF
--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -7,20 +7,70 @@ info:
 paths:
   /api/memos:
     get:
-      summary: 모든 메모 조회
-      description: 생성일 기준 내림차순으로 정렬된 모든 메모를 조회합니다.
+      summary: 메모 조회 및 검색
+      description: 쿼리 파라미터를 사용하여 메모를 조회하거나 검색할 수 있습니다. 기본적으로 생성일 기준 내림차순으로 정렬됩니다.
+      parameters:
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 메모 제목과 내용에서 검색할 키워드
+          example: '프로젝트'
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 특정 카테고리로 필터링 (all이면 모든 카테고리)
+          example: '업무'
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [createdAt, updatedAt, title]
+            default: createdAt
+          description: 정렬 기준
+        - name: sortOrder
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: 정렬 순서
       responses:
         '200':
-          description: 메모 목록 조회 성공
+          description: 메모 목록 조회/검색 성공
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  memos:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Memo'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Memo'
+              examples:
+                all_memos:
+                  summary: 모든 메모 조회
+                  value:
+                    - id: 'memo1'
+                      title: '회의 내용'
+                      content: '프로젝트 관련 회의 내용입니다.'
+                      category: '업무'
+                      createdAt: '2025-06-16T10:00:00Z'
+                    - id: 'memo2'
+                      title: '개인 일정'
+                      content: '주말 계획을 세워보자.'
+                      category: '개인'
+                      createdAt: '2025-06-15T15:30:00Z'
+                search_result:
+                  summary: 검색 결과 예시
+                  value:
+                    - id: 'memo1'
+                      title: '회의 내용'
+                      content: '프로젝트 관련 회의 내용입니다.'
+                      category: '업무'
+                      createdAt: '2025-06-16T10:00:00Z'
         '500':
           description: 서버 에러
           content:

--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -2,10 +2,21 @@ import { withAuth } from '@/lib/auth-middleware';
 import { createMemo, getMemos } from '@/lib/services/memo.service';
 import { type NextRequest, NextResponse } from 'next/server';
 
-// GET /api/memos - 메모 목록 조회
 export const GET = withAuth(async (req: NextRequest, { userId }) => {
   try {
-    const memos = await getMemos(userId);
+    const { searchParams } = new URL(req.url);
+    const search = searchParams.get('search');
+    const category = searchParams.get('category');
+    const sortBy = searchParams.get('sortBy') as 'createdAt' | 'updatedAt' | 'title';
+    const sortOrder = searchParams.get('sortOrder') as 'asc' | 'desc';
+
+    const memos = await getMemos(userId, {
+      search: search || undefined,
+      category: category || undefined,
+      sortBy: sortBy || 'createdAt',
+      sortOrder: sortOrder || 'desc',
+    });
+
     return NextResponse.json(memos);
   } catch (error) {
     console.error('Error fetching memos:', error);
@@ -13,7 +24,6 @@ export const GET = withAuth(async (req: NextRequest, { userId }) => {
   }
 });
 
-// POST /api/memos - 새 메모 생성
 export const POST = withAuth(async (req: NextRequest, { userId }) => {
   try {
     const body = await req.json();

--- a/src/hooks/useSearchMemos.ts
+++ b/src/hooks/useSearchMemos.ts
@@ -1,0 +1,58 @@
+import { useAuth } from '@/hooks/useAuth';
+import { queryKeys } from '@/lib/queryKeys';
+import type { MemoProps } from '@/types/memo';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+export interface SearchOptions {
+  search?: string;
+  category?: string;
+  sortBy?: 'createdAt' | 'updatedAt' | 'title';
+  sortOrder?: 'asc' | 'desc';
+}
+
+const fetchSearchMemos = async (options: SearchOptions): Promise<MemoProps[]> => {
+  const { search, category, sortBy = 'createdAt', sortOrder = 'desc' } = options;
+  const params = new URLSearchParams();
+
+  if (search) params.append('search', search);
+  if (category) params.append('category', category);
+  params.append('sortBy', sortBy);
+  params.append('sortOrder', sortOrder);
+
+  try {
+    const response = await fetch(`/api/memos?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Failed to fetch memos:', error);
+    throw error instanceof Error ? error : new Error('Unknown error fetching memos');
+  }
+};
+
+export default function useSearchMemos(options: SearchOptions) {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const queryKey = useMemo(
+    () =>
+      queryKeys.memo.search({
+        search: options.search,
+        category: options.category,
+        sortBy: options.sortBy,
+        sortOrder: options.sortOrder,
+      }),
+    [options.search, options.category, options.sortBy, options.sortOrder],
+  );
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey,
+    queryFn: () => fetchSearchMemos(options),
+    staleTime: options.search ? 30 * 1000 : 5 * 60 * 1000,
+    enabled: isAuthenticated && !authLoading,
+    placeholderData: keepPreviousData,
+  });
+
+  return { data, isLoading, isError, isFetching };
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,3 +1,5 @@
+import type { SearchOptions } from '@/hooks/useSearchMemos';
+
 export const queryKeys = {
   memo: {
     all: ['memos'] as const,
@@ -5,6 +7,7 @@ export const queryKeys = {
     list: (filters: string) => [...queryKeys.memo.lists(), { filters }] as const,
     details: () => [...queryKeys.memo.all, 'detail'] as const,
     detail: (id: string) => [...queryKeys.memo.details(), id] as const,
+    search: (options: SearchOptions) => [...queryKeys.memo.all, 'search', options] as const,
   },
 
   category: {

--- a/src/lib/services/memo.service.ts
+++ b/src/lib/services/memo.service.ts
@@ -60,9 +60,9 @@ export async function getMemos(
   const memosRef = collection(db, 'users', userId, 'memos');
 
   const queryConstraints = [orderBy(sortBy, sortOrder), where('isDeleted', '!=', true)];
+  const categoryMap = await getCategoryMap(userId);
 
   if (category && category !== 'all') {
-    const categoryMap = await getCategoryMap(userId);
     const categoryId = Array.from(categoryMap.entries()).find(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       ([_, name]) => name === category,
@@ -75,7 +75,6 @@ export async function getMemos(
 
   const q = query(memosRef, ...queryConstraints);
   const querySnapshot = await getDocs(q);
-  const categoryMap = await getCategoryMap(userId);
 
   let memos = querySnapshot.docs.map(doc => {
     const data = doc.data();

--- a/src/lib/services/memo.service.ts
+++ b/src/lib/services/memo.service.ts
@@ -46,24 +46,58 @@ export async function createMemo(
   };
 }
 
-export async function getMemos(userId: string): Promise<MemoProps[]> {
+export async function getMemos(
+  userId: string,
+  options?: {
+    search?: string;
+    category?: string;
+    sortBy?: 'createdAt' | 'updatedAt' | 'title';
+    sortOrder?: 'asc' | 'desc';
+  },
+): Promise<MemoProps[]> {
+  const { search, category, sortBy = 'createdAt', sortOrder = 'desc' } = options || {};
+
   const memosRef = collection(db, 'users', userId, 'memos');
-  const q = query(memosRef, orderBy('createdAt', 'desc'), where('isDeleted', '!=', true));
+
+  const queryConstraints = [orderBy(sortBy, sortOrder), where('isDeleted', '!=', true)];
+
+  if (category && category !== 'all') {
+    const categoryMap = await getCategoryMap(userId);
+    const categoryId = Array.from(categoryMap.entries()).find(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ([_, name]) => name === category,
+    )?.[0];
+
+    if (categoryId) {
+      queryConstraints.push(where('categoryId', '==', categoryId));
+    }
+  }
+
+  const q = query(memosRef, ...queryConstraints);
   const querySnapshot = await getDocs(q);
   const categoryMap = await getCategoryMap(userId);
 
-  return Promise.all(
-    querySnapshot.docs.map(async doc => {
-      const data = doc.data();
-      return {
-        id: doc.id,
-        title: data.title,
-        content: data.content,
-        category: categoryMap.get(data.categoryId) || 'others',
-        createdAt: Timestamp.fromDate(data.createdAt.toDate()),
-      } as MemoProps;
-    }),
-  );
+  let memos = querySnapshot.docs.map(doc => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      title: data.title,
+      content: data.content,
+      category: categoryMap.get(data.categoryId) || 'others',
+      createdAt: Timestamp.fromDate(data.createdAt.toDate()),
+    } as MemoProps;
+  });
+
+  if (search && search.trim()) {
+    const normalizedQuery = search.toLowerCase().trim();
+    memos = memos.filter(
+      memo =>
+        memo.title.toLowerCase().includes(normalizedQuery) ||
+        memo.content.toLowerCase().includes(normalizedQuery),
+    );
+  }
+
+  return memos;
 }
 
 export async function getMemoById(id: string, userId: string): Promise<MemoProps | null> {


### PR DESCRIPTION
- 기존 GET api/memos 에서 검색 조회 및 필터링 기능을 추가함



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 메모 목록 조회 시 검색어, 카테고리, 정렬 기준(생성일, 수정일, 제목) 및 정렬 순서(오름차순/내림차순)로 필터링 및 정렬이 가능해졌습니다.
    - 메모 검색 및 필터링을 위한 React 훅이 추가되어, 사용자 인터페이스에서 쉽게 메모를 조회할 수 있습니다.
- **Documentation**
    - 메모 조회 API 문서에 새로운 쿼리 파라미터와 응답 예시가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->