### PR TITLE
bug: initialData 오사용으로 인해 useCategories가 데이터를 불러오지 못하는 현상 수정

### DIFF
--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -22,8 +22,9 @@ export default function useCategories() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['categories'],
     queryFn: fetchCategories,
-    placeholderData: [],
   });
+  
+  const categories = data ?? []; // undefined 방어 코드
 
-  return { categories: data, isLoading, isError };
+  return { categories, isLoading, isError };
 }


### PR DESCRIPTION
## 📋 작업 세부 사항

useCategories의 initialData 제거 및 data undefined 시 []로 대체

## 🔧 변경 사항 요약

useCategories의 initialData 제거 및 data undefined 시 []로 대체

![image](https://github.com/user-attachments/assets/ed366056-636e-4430-acad-8a5f9394373e)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 카테고리 데이터가 없을 때 빈 배열로 안전하게 처리되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->