### PR TITLE
fix: 사이드바에서 memo 개수가 0인 카테고리는 숨김처리

### DIFF
--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import Separator from '@/components/common/Separator';
 
 import { Skeleton } from '@/components/common/Skeleton';
 import useCategories from '@/hooks/useCategories';
+import { useMemo } from 'react';
 import CategoryItem from './CategoryItem';
 
 interface SidebarProps {
@@ -12,6 +13,11 @@ interface SidebarProps {
 
 export default function Sidebar({ isOpen }: SidebarProps) {
   const { categories, isError, isLoading } = useCategories();
+
+  const fiteredCategories = useMemo(
+    () => categories.filter(categorie => categorie.memoCount > 0),
+    [categories],
+  );
 
   return (
     <aside
@@ -40,7 +46,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
             <br /> 로그인 후 다시 시도해주세요.
           </li>
         )}
-        {categories.map((category, index) => (
+        {fiteredCategories.map((category, index) => (
           <CategoryItem
             key={`category-${category.name}-${index}`}
             name={category.name}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,5 +1,6 @@
 import type { CategoryItem } from '@/types/category';
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
 const fetchCategories = async (): Promise<CategoryItem[]> => {
   try {
@@ -22,8 +23,9 @@ export default function useCategories() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['categories'],
     queryFn: fetchCategories,
-    initialData: [],
   });
 
-  return { categories: data, isLoading, isError };
+  const categories = useMemo(() => data || [], [data]);
+
+  return { categories, isLoading, isError };
 }

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -20,12 +20,12 @@ const fetchCategories = async (): Promise<CategoryItem[]> => {
 };
 
 export default function useCategories() {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError } = useQuery<CategoryItem[], Error>({
     queryKey: ['categories'],
     queryFn: fetchCategories,
   });
 
-  const categories = useMemo(() => data || [], [data]);
+  const categories = useMemo<CategoryItem[]>(() => data || [], [data]);
 
   return { categories, isLoading, isError };
 }


### PR DESCRIPTION
## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 사이드바에서 메모가 없는 카테고리는 목록에 표시되지 않도록 변경되었습니다.
  - 카테고리 목록이 항상 안정적으로 메모이제이션되어, 성능과 렌더링 효율이 향상되었습니다.
  - 카테고리 데이터가 항상 정의된 배열로 제공되어, 로딩 중에도 안정적으로 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->