### PR TITLE
fix: 모바일 마크다운 에디터 툴바 스타일 개선

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -51,7 +51,7 @@ export const Modal = ({ isOpen, onClose, children, size = 'large', className }: 
       <div
         ref={modalRef}
         className={cn(
-          'relative z-50 w-full rounded-lg bg-white p-6 shadow-xl',
+          'relative z-50 w-full rounded-lg bg-white p-5 shadow-xl',
           sizeClasses[size],
           className,
         )}

--- a/src/components/memo-editor/LexicalMarkdownEditor/LexicalMarkdownEditor.toolbar.css
+++ b/src/components/memo-editor/LexicalMarkdownEditor/LexicalMarkdownEditor.toolbar.css
@@ -13,6 +13,11 @@
   gap: 4px;
   border: 1px solid #ccc;
   border-bottom: none;
+
+  @media screen and (max-width: 640px) {
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+  }
 }
 
 /* Mobile Toolbar Styles */
@@ -61,14 +66,10 @@
 }
 
 .mobile-toolbar-item {
-  border: 0;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  min-width: 36px;
-  min-height: 36px;
-  flex: 1;
+  @media (width >= 40rem /* 640px */) {
+    display: block;
+  }
+  display: none;
 }
 
 .mobile-toolbar-item:disabled {
@@ -156,11 +157,19 @@
   gap: 8px;
   padding: 8px 12px;
   min-width: auto;
+  @media screen and (max-width: 640px) {
+    padding: 0px 0px;
+    width: 50px;
+  }
 }
 
 .toolbar button.block-controls .text {
   font-size: 14px;
   color: #333;
+
+  @media screen and (max-width: 640px) {
+    font-size: 12px;
+  }
 }
 
 .chevron-down.inside {

--- a/src/components/memo-editor/LexicalMarkdownEditor/LexicalMarkdownEditor.tsx
+++ b/src/components/memo-editor/LexicalMarkdownEditor/LexicalMarkdownEditor.tsx
@@ -27,7 +27,6 @@ import './LexicalMarkdownEditor.toolbar.css';
 import AutoLinkPlugin from './plugins/AutoLinkPlugin';
 import CodeHighlightPlugin from './plugins/CodeHighlightPlugin';
 import ListMaxIndentLevelPlugin from './plugins/ListMaxIndentLevelPlugin';
-import MobileToolbarPlugin from './plugins/MobileToolbarPlugin';
 import ToolbarPlugin from './plugins/ToolbarPlugin';
 
 interface LexicalMarkdownEditorProps {
@@ -93,19 +92,17 @@ export default function LexicalMarkdownEditor({
     <div className="sm:h-[80%] h-[87%] w-full">
       <LexicalComposer initialConfig={initialConfig}>
         <div className="h-full flex flex-col relative">
-          {!isMobile && <ToolbarPlugin />}
+          <ToolbarPlugin />
           <RichTextPlugin
             contentEditable={
               <ContentEditable
-                className={`flex-1 p-4 outline-none resize-none border border-gray-300 ${
-                  !isMobile ? 'rounded-b-lg' : 'rounded-lg'
-                } overflow-y-auto focus:border-blue-500 focus:ring-1 focus:ring-blue-500 ${
+                className={`flex-1 p-4 outline-none resize-none border border-gray-300 overflow-y-auto focus:border-blue-500 focus:ring-1 focus:ring-blue-500 ${
                   isMobile ? 'pb-20' : ''
                 }`}
               />
             }
             placeholder={
-              <div className={`text-gray-400 absolute ${!isMobile ? 'top-16' : 'top-4'} left-4`}>
+              <div className={`sm:hidden text-gray-400 absolute sm:top-4 top-[60px] left-4`}>
                 {placeholder}
               </div>
             }
@@ -120,7 +117,7 @@ export default function LexicalMarkdownEditor({
           <AutoLinkPlugin />
           <CodeHighlightPlugin />
           <ListMaxIndentLevelPlugin maxDepth={7} />
-          {isMobile && <MobileToolbarPlugin />}
+          {/* {isMobile && <MobileToolbarPlugin />} */}
         </div>
       </LexicalComposer>
     </div>

--- a/src/components/memo-editor/LexicalMarkdownEditor/plugins/ToolbarPlugin.tsx
+++ b/src/components/memo-editor/LexicalMarkdownEditor/plugins/ToolbarPlugin.tsx
@@ -60,14 +60,14 @@ const LowPriority = 1;
 const supportedBlockTypes = new Set(['paragraph', 'quote', 'code', 'h1', 'h2', 'h3', 'ul', 'ol']);
 
 const blockTypeToBlockName = {
-  code: 'Code Block',
-  h1: 'Heading 1',
-  h2: 'Heading 2',
-  h3: 'Heading 3',
-  ol: 'Numbered List',
+  code: 'Code',
+  h1: 'H1',
+  h2: 'H2',
+  h3: 'H3',
+  ol: 'OL',
   paragraph: 'Normal',
   quote: 'Quote',
-  ul: 'Bulleted List',
+  ul: 'UL',
 };
 
 function getBlockTypeIcon(blockType: string) {
@@ -420,7 +420,7 @@ export default function ToolbarPlugin() {
       >
         <BiRedo className="w-4 h-4" />
       </button>
-      <div className="divider" />
+      {/* <div className="divider" /> */}
       {supportedBlockTypes.has(blockType) && (
         <>
           <button
@@ -442,7 +442,7 @@ export default function ToolbarPlugin() {
               setShowBlockOptionsDropDown={setShowBlockOptionsDropDown}
             />
           )}
-          <div className="divider" />
+          {/* <div className="divider" /> */}
         </>
       )}
       {blockType === 'code' ? (
@@ -516,12 +516,12 @@ export default function ToolbarPlugin() {
             <BiLink className="w-4 h-4" />
           </button> */}
           {isLink && <div className="divider" />}
-          <div className="divider" />
+          {/* <div className="divider" /> */}
           <button
             onClick={() => {
               editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
             }}
-            className="toolbar-item spaced"
+            className="mobile-toolbar-item"
             aria-label="Left Align"
           >
             <BiAlignLeft className="w-4 h-4" />
@@ -530,7 +530,7 @@ export default function ToolbarPlugin() {
             onClick={() => {
               editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
             }}
-            className="toolbar-item spaced"
+            className="mobile-toolbar-item"
             aria-label="Center Align"
           >
             <BiAlignMiddle className="w-4 h-4" />
@@ -539,7 +539,7 @@ export default function ToolbarPlugin() {
             onClick={() => {
               editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
             }}
-            className="toolbar-item spaced"
+            className="mobile-toolbar-item"
             aria-label="Right Align"
           >
             <BiAlignRight className="w-4 h-4" />
@@ -548,7 +548,7 @@ export default function ToolbarPlugin() {
             onClick={() => {
               editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
             }}
-            className="toolbar-item"
+            className="mobile-toolbar-item"
             aria-label="Justify Align"
           >
             <BiAlignJustify className="w-4 h-4" />


### PR DESCRIPTION
- 모바일에서 툴바 아이콘 크기를 줄이고, 불필요한 구분선을 제거
- 툴바 아이콘의 이름을 간단하게 변경 (예: "Heading 1" -> "H1")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 모달 내부 패딩이 소폭 줄어들어 공간 활용이 개선되었습니다.
  - 마크다운 에디터 툴바가 모바일 환경에서 더 깔끔하게 보이도록 스타일이 개선되었습니다.
  - 툴바 버튼, 구분선, 텍스트 크기 등이 모바일 화면에 맞게 조정되었습니다.

- **버그 수정**
  - 모바일 환경에서 툴바가 항상 보이도록 렌더링 방식이 변경되었습니다.

- **리팩터**
  - 툴바 내 블록 타입 명칭이 간결하게 변경되었습니다(예: "Heading 1" → "H1", "Numbered List" → "OL" 등).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->