### PR TITLE
fix: memo update API 가 title과 content 둘중 하나만 있어도가능

### DIFF
--- a/src/app/api/memos/[id]/route.ts
+++ b/src/app/api/memos/[id]/route.ts
@@ -35,8 +35,8 @@ export const PUT = withAuth(async (req: NextRequest, { userId, params }) => {
 
     const { title, content, category } = body;
 
-    if (!title || !content) {
-      return NextResponse.json({ error: 'Title and content are required' }, { status: 400 });
+    if (!(title || content)) {
+      return NextResponse.json({ error: 'Title or Content is required' }, { status: 400 });
     }
 
     await updateMemo(id, { title, content, category: category || 'others' }, userId);


### PR DESCRIPTION
- title와 content중 하나만 있어도 메모 수정이 가능하도록함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 메모 수정 시 제목과 내용 중 적어도 하나만 입력해도 업데이트가 가능하도록 검증 로직이 개선되었습니다.
	- 오류 메시지가 "제목 또는 내용이 필요합니다"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->