### PR TITLE
fix: URL 경로 변수화 및 카테고리 URL 경로 수정

### DIFF
--- a/src/app/categories/[category]/page.tsx
+++ b/src/app/categories/[category]/page.tsx
@@ -1,7 +1,7 @@
 import ClientMemoSection from '@/components/ClientMemoSection';
+import { fetchMemos } from '@/lib/fetchers';
 import type { MemoProps } from '@/types/memo';
 import { cookies } from 'next/headers';
-import { fetchMemos } from '@/lib/fetchers';
 
 interface PageProps {
   category: string;
@@ -12,7 +12,7 @@ async function getMemos(): Promise<MemoProps[]> {
   return fetchMemos(cookieStore);
 }
 
-export default async function EachCategoryPage({ params }: { params: Promise<PageProps>}) {
+export default async function EachCategoryPage({ params }: { params: Promise<PageProps> }) {
   const { category } = await params;
   const memos = await getMemos();
 

--- a/src/components/constants/path.ts
+++ b/src/components/constants/path.ts
@@ -1,0 +1,4 @@
+export const ROUTE = {
+  HOME: '/',
+  CATEGORIES: '/categories',
+} as const;

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@
 import Separator from '@/components/common/Separator';
 
 import { Skeleton } from '@/components/common/Skeleton';
+import { ROUTE } from '@/components/constants/path';
 import useCategories from '@/hooks/useCategories';
 import { useMemo } from 'react';
 import CategoryItem from './CategoryItem';
@@ -50,7 +51,7 @@ export default function Sidebar({ isOpen }: SidebarProps) {
           <CategoryItem
             key={`category-${category.name}-${index}`}
             name={category.name}
-            route={`/categories/${category.name}`}
+            route={`${ROUTE.CATEGORIES}/${encodeURIComponent(category.name)}`}
             count={category.memoCount}
           />
         ))}

--- a/src/components/memo/MemoEachSection.tsx
+++ b/src/components/memo/MemoEachSection.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import MemoList from './MemoList';
-import Link from 'next/link';
 import Separator from '@/components/common/Separator';
 import ToggleButton from '@/components/common/ToggleButton';
-import { useState } from 'react';
+import { ROUTE } from '@/components/constants/path';
 import type { MemoListProps } from '@/types/memo';
+import Link from 'next/link';
+import { useState } from 'react';
+import MemoList from './MemoList';
 
 interface MemoEachSectionProps {
   category: string;
@@ -22,7 +23,10 @@ export default function MemoEachSection({ category, memos }: MemoEachSectionProp
   return (
     <div className="mb-6">
       <div className="flex justify-between">
-        <Link href={`/category/${encodeURIComponent(category)}`} className="font-medium inline-block">
+        <Link
+          href={`${ROUTE.CATEGORIES}/${encodeURIComponent(category)}`}
+          className="font-medium inline-block"
+        >
           {category}
         </Link>
         <ToggleButton onClick={toggleOpen} isOpen={isOpen} />


### PR DESCRIPTION
- src/app/(category)/category/[category]/page.tsx 파일을 src/app/categories/[category]/page.tsx로 경로 변경
- MemoEachSection 컴포넌트에서 Link 경로를 수정하여 categories 경로로 변경. path.ts의 ROUTE.CATEGORIES 상수를 사용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 중앙에서 관리되는 경로 상수(ROUTE)가 추가되어 홈과 카테고리 경로를 일관되게 사용할 수 있게 되었습니다.

- **리팩터**
  - 카테고리 및 메모 관련 링크 생성 시 하드코딩된 경로 대신 경로 상수를 사용하도록 개선되어 유지보수성이 향상되었습니다.
  - URL 생성 시 카테고리명이 안전하게 인코딩되도록 처리되었습니다.

- **스타일**
  - 코드 가독성을 위한 import 정렬 및 코드 스타일이 일부 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->