### PR TITLE
fix: queryKey 간소화 및 불필요한 타입 제거

### DIFF
--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,10 +1,12 @@
 export const queryKeys = {
   memo: {
     lists: () => ['memos-list'] as const,
-    detail: (id?: string) => ['memos-detail-item', id] as const,
+    detail: (id: string) => ['memos-detail-item', id] as const,
+    details: () => ['memos-detail-items'] as const,
   },
   category: {
     lists: () => ['categories-list'] as const,
-    detail: (id?: string) => ['categories-detail', id] as const,
+    detail: (id: string) => ['categories-detail', id] as const,
+    details: () => ['categories-detail-items'] as const,
   },
 } as const;


### PR DESCRIPTION
- queryKeys.memo의 리스트 및 상세 조회 키를 간소화
    - 메모 리스트는 ['memos-list']로 변경
    - 메모 상세 조회는 ['memos-detail-item', id]로 변경
    - 카테고리 리스트는 ['categories-list']로 변경
    - 카테고리 상세 조회는 ['categories-detail', id]로 변경
    - 그외 tanstack queryKeys는 삭제

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 메모와 카테고리 관련 쿼리 키 구조가 단순화되어, 더 간결하고 일관된 형태로 변경되었습니다.  
  - 메모와 카테고리 항목에 새로운 세부 정보 키가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->