### PR TITLE
feat: 메모 생성/수정/삭제시 카테고리가 업데이트 되지 않는 오류 수정

### DIFF
--- a/src/hooks/useDeleteMemo.ts
+++ b/src/hooks/useDeleteMemo.ts
@@ -54,6 +54,9 @@ export default function useDeleteMemo() {
         queryClient.setQueryData(queryKeys.memo.lists(), context.previousMemos);
       }
     },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.category.lists() });
+    },
   });
   return { deleteMemo: mutateAsync };
 }

--- a/src/hooks/usePostMemo.ts
+++ b/src/hooks/usePostMemo.ts
@@ -63,10 +63,7 @@ export default function usePostMemo() {
           memo.id === context.newOptimisticMemo?.id ? { ...memo, ...createdMemo } : memo,
         );
       });
-      const categories = queryClient.getQueryData<string[]>(['categories']);
-      if (categories && !categories.includes(createdMemo.category)) {
-        queryClient.setQueryData(['categories'], [...categories, createdMemo.category]);
-      }
+      queryClient.invalidateQueries({ queryKey: queryKeys.category.lists() });
     },
     onError: (error, newMemo, context) => {
       queryClient.setQueryData<MemoProps[]>(queryKeys.memo.lists(), context?.previousMemos);

--- a/src/hooks/useUpdateMemo.ts
+++ b/src/hooks/useUpdateMemo.ts
@@ -75,6 +75,9 @@ export default function useUpdateMemo() {
       console.error('Error updating memo:', error);
       throw error;
     },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.category.lists() });
+    },
   });
 
   return { updateMemo: mutation.mutate };

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -1,11 +1,11 @@
 export const queryKeys = {
   memo: {
-    lists: () => ['memos-list'] as const,
+    lists: () => ['memos'] as const,
     detail: (id: string) => ['memos-detail-item', id] as const,
     details: () => ['memos-detail-items'] as const,
   },
   category: {
-    lists: () => ['categories-list'] as const,
+    lists: () => ['categories'] as const,
     detail: (id: string) => ['categories-detail', id] as const,
     details: () => ['categories-detail-items'] as const,
   },

--- a/src/lib/services/memo.service.ts
+++ b/src/lib/services/memo.service.ts
@@ -190,13 +190,13 @@ export async function removeCategoryAndUpdateMemos(
   userId: string,
 ): Promise<void> {
   const memosRef = collection(db, 'users', userId, 'memos');
-  const q = query(memosRef, where('category', '==', categoryId));
+  const q = query(memosRef, where('categoryId', '==', categoryId));
   const querySnapshot = await getDocs(q);
   const batch = writeBatch(db);
 
   for (const docSnap of querySnapshot.docs) {
     const memoRef = doc(memosRef, docSnap.id);
-    batch.update(memoRef, { category: newCategoryId });
+    batch.update(memoRef, { categoryId: newCategoryId });
   }
 
   await batch.commit();


### PR DESCRIPTION
- 카테고리 삭제시 메모의 카테고리 ID를 업데이트하는 로직에서
  `category` 필드가 아닌 `categoryId` 필드를 사용하도록 수정
- 메모 생성/삭제/수정시 에도 카테고리를 업데이트 하도록 수정함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 메모 삭제, 생성, 수정 시 카테고리 목록이 올바르게 갱신되도록 개선되었습니다.
  - 카테고리 변경 시 메모 데이터가 올바른 필드(`categoryId`)로 업데이트되도록 수정되었습니다.

- **기타 개선**
  - 내부 캐시 갱신 방식이 단순화되어 데이터 동기화가 더욱 신뢰성 있게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->