### PR TITLE
feat: layout.tsx에 동적 metadata 구조 적용 & 카테고리 별 페이지에서 동적 metadata 사용

### DIFF
--- a/src/app/categories/[category]/page.tsx
+++ b/src/app/categories/[category]/page.tsx
@@ -3,8 +3,15 @@ import { fetchMemos } from '@/lib/fetchers';
 import type { MemoProps } from '@/types/memo';
 import { cookies } from 'next/headers';
 
-interface PageProps {
+interface CategoryParams {
   category: string;
+}
+
+export async function generateMetadata({params}: {params : Promise<CategoryParams>}){
+  const { category } = await params;
+  return {
+    title: category,
+  }
 }
 
 async function getMemos(): Promise<MemoProps[]> {
@@ -12,7 +19,7 @@ async function getMemos(): Promise<MemoProps[]> {
   return fetchMemos(cookieStore);
 }
 
-export default async function EachCategoryPage({ params }: { params: Promise<PageProps> }) {
+export default async function EachCategoryPage({ params }: { params: Promise<CategoryParams> }) {
   const { category } = await params;
   const memos = await getMemos();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,10 @@ const pretendard = localFont({
 });
 
 export const metadata: Metadata = {
-  title: 'Memo',
+  title: {
+    template: '%s | Memoji',
+    default: 'Memoji',
+  },
   description: 'Simple Memo App',
 };
 


### PR DESCRIPTION
## 📋 작업 세부 사항

layout.tsx에 동적 metadata 구조 적용 & 카테고리 별 페이지에서 동적 metadata 사용

## 🔧 변경 사항 요약

- layout.tsx에 정적으로 정의된 metadata를 template, default로 나누고 `%s`를 받게하여 동적으로 metadata를 받을 수 있는 구조로 변경
- 카테고리별 페이지에서 params를 받아 동적 metadata를 적용
- 기존 interface를 광범위한 이름으로 변경

![image](https://github.com/user-attachments/assets/efa9adcf-d5a8-49a9-adf4-ea03d0853db0)

