### PR TITLE
feat: 카테고리 생성/수정 시 특수문자 포함 금지 조건 추가

### DIFF
--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -5,6 +5,7 @@ import useCategories from '@/hooks/useCategories';
 import useCreateCategory from '@/hooks/useCreateCategory';
 import useDeleteCategory from '@/hooks/useDeleteCategory';
 import useModifyCategory from '@/hooks/useModifyCategory';
+import { validateCategoryName } from '@/utils/validateCategoryName';
 import { useEffect, useState } from 'react';
 import { FaPlus, FaTimes } from 'react-icons/fa';
 import { FaCheck } from 'react-icons/fa6';
@@ -69,6 +70,9 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
       categoryStates.some(category => category.name.toLowerCase() === newCategoryName.toLowerCase())
     ) {
       setErrorMsg('이미 존재하는 카테고리입니다.');
+      return;
+    } else if (!validateCategoryName(newCategoryName)) {
+      setErrorMsg('특수문자는 사용할 수 없습니다.');
       return;
     } else {
       // 1. 로컬 상태 업데이트 (낙관적 업데이트)

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -158,6 +158,13 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           ),
         );
         return;
+      } else if (!validateCategoryName(newCategoryName)) {
+        setCategoryStates(prev =>
+          prev.map((state, i) =>
+            i === index ? { ...state, error: '특수문자는 사용할 수 없습니다.' } : state,
+          ),
+        );
+        return;
       }
 
       // 로컬 상태만 수정(isEditing / error)


### PR DESCRIPTION
## 📋 작업 세부 사항

카테고리 생성/수정 시 특수문자 포함 금지 조건 추가

## 🔧 변경 사항 요약

`validateCategoryName()`을 통과하지 못하면 "특수문자는 사용할 수 없습니다." 라는 오류 메시지가 나오도록 조건 추가
![valid](https://github.com/user-attachments/assets/af43d013-1cf5-4317-943a-37b3d5181e4c)

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 카테고리 생성 및 수정 시 특수문자가 포함된 이름을 입력할 경우 "특수문자는 사용할 수 없습니다."라는 오류 메시지가 표시되도록 검증 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->