### PR TITLE
feat: 에러 페이지, 로딩 페이지, not-found 페이지 추가

### DIFF
--- a/src/app/categories/[category]/loading.tsx
+++ b/src/app/categories/[category]/loading.tsx
@@ -1,5 +1,5 @@
 import MemoListSkeleton from '@/components/common/MemoListSkeleton';
 
-export default function loading() {
+export default function Loading() {
   return <MemoListSkeleton />;
 }

--- a/src/app/categories/[category]/loading.tsx
+++ b/src/app/categories/[category]/loading.tsx
@@ -1,0 +1,5 @@
+import MemoListSkeleton from '@/components/common/MemoListSkeleton';
+
+export default function loading() {
+  return <MemoListSkeleton />;
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import ErrorFallback from '@/components/common/ErrorFallback';
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return <ErrorFallback reset={reset} />;
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,7 +4,7 @@ import { IoHomeOutline } from 'react-icons/io5';
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-gradient-to-br   flex flex-col items-center justify-center p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
       <div className="text-center space-y-6 max-w-md">
         <div className="space-y-2">
           <h1 className="text-8xl font-black text-gray-900 tracking-tight">404</h1>
@@ -13,7 +13,7 @@ export default function NotFound() {
 
         <div className="space-y-3">
           <h2 className="text-2xl font-bold text-gray-800">페이지를 찾을 수 없습니다</h2>
-          <p className="text-gray leading-relaxed">
+          <p className="text-gray-600 leading-relaxed">
             요청하신 페이지가 존재하지 않거나
             <br />
             이동되었을 수 있습니다.

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import { ROUTE } from '@/components/constants/path';
+import Link from 'next/link';
+import { IoHomeOutline } from 'react-icons/io5';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br   flex flex-col items-center justify-center p-4">
+      <div className="text-center space-y-6 max-w-md">
+        <div className="space-y-2">
+          <h1 className="text-8xl font-black text-gray-900 tracking-tight">404</h1>
+          <div className="w-24 h-1 bg-black mx-auto"></div>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-2xl font-bold text-gray-800">페이지를 찾을 수 없습니다</h2>
+          <p className="text-gray leading-relaxed">
+            요청하신 페이지가 존재하지 않거나
+            <br />
+            이동되었을 수 있습니다.
+          </p>
+        </div>
+        <Link
+          className="inline-flex items-center px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+          href={ROUTE.HOME}
+        >
+          <IoHomeOutline className="w-4 h-4 mr-2" />
+          홈으로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ClientHome.tsx
+++ b/src/components/ClientHome.tsx
@@ -1,13 +1,14 @@
 'use client';
 import LoginPrompt from '@/components/auth/LoginPrompt';
+import ErrorFallback from '@/components/common/ErrorFallback';
 import MemoListSkeleton from '@/components/common/MemoListSkeleton';
+import { NotFoundMemos } from '@/components/common/NotFoundMemos';
 import MemoSection from '@/components/memo/MemoSection';
-import MemoLoadErrorFallback from '@/components/MemoLoadErrorFallback';
-import { NotFoundMemos } from '@/components/NotFoundMemos';
 import { useAuth } from '@/hooks/useAuth';
 import useDebounce from '@/hooks/useDebounce';
 import useSearchMemos from '@/hooks/useSearchMemos';
 import { useSearchStore } from '@/store/SearchStore';
+import { useRouter } from 'next/navigation';
 
 export default function ClientHome() {
   const searchQuery = useSearchStore(state => state.searchQuery);
@@ -21,9 +22,15 @@ export default function ClientHome() {
     search: debouncedValue,
     category: '',
   });
+  const router = useRouter();
 
   if (isError) {
-    return <MemoLoadErrorFallback />;
+    return (
+      <ErrorFallback
+        reset={() => router.refresh()}
+        error={new Error('메모를 가져오는 중 오류가 발생했습니다')}
+      />
+    );
   }
 
   if (isLoading || isDebouncing || isAuthLoading) {

--- a/src/components/NotFoundMemos.tsx
+++ b/src/components/NotFoundMemos.tsx
@@ -1,7 +1,0 @@
-export function NotFoundMemos() {
-  return (
-    <div className="flex items-center justify-center h-full">
-      <p className="text-gray-500">메모가 없습니다.</p>
-    </div>
-  );
-}

--- a/src/components/auth/LoginPrompt.tsx
+++ b/src/components/auth/LoginPrompt.tsx
@@ -1,20 +1,34 @@
 'use client';
 import SignInModal from '@/components/auth/SignInModal';
 import { useState } from 'react';
+import { IoLogInOutline } from 'react-icons/io5';
 
 export default function LoginPrompt() {
   const [isSignInOpen, setIsSignInOpen] = useState(false);
 
   return (
     <>
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <h2 className="text-xl font-semibold mb-2">로그인이 필요합니다</h2>
-          <p className="text-gray-600 mb-6">메모 기능을 사용하려면 로그인해주세요.</p>
+      <div className="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4">
+        <div className="text-center space-y-6 max-w-md">
+          <div className="space-y-2">
+            <h1 className="text-8xl font-black text-gray-900 tracking-tight">🔐</h1>
+            <div className="w-24 h-1 bg-black mx-auto"></div>
+          </div>
+
+          <div className="space-y-3">
+            <h2 className="text-2xl font-bold text-gray-800">로그인이 필요합니다</h2>
+            <p className="text-gray leading-relaxed">
+              메모 기능을 사용하려면
+              <br />
+              로그인해주세요.
+            </p>
+          </div>
+
           <button
             onClick={() => setIsSignInOpen(true)}
-            className="bg-gray-700 hover:bg-gray-500 text-white font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer"
+            className="inline-flex items-center px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
           >
+            <IoLogInOutline className="w-4 h-4 mr-2" />
             로그인하기
           </button>
         </div>

--- a/src/components/common/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback.tsx
@@ -1,0 +1,37 @@
+import { MdRefresh } from 'react-icons/md';
+
+interface ErrorFallbackProps {
+  error?: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorFallback({ error, reset }: ErrorFallbackProps) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4">
+      <div className="text-center space-y-6 max-w-md">
+        <div className="space-y-2">
+          <h1 className="text-8xl font-black text-gray-900 tracking-tight">!</h1>
+          <div className="w-24 h-1 bg-black mx-auto"></div>
+        </div>
+
+        <div className="space-y-3">
+          <h2 className="text-2xl font-bold text-gray-800">오류가 발생했습니다</h2>
+          <p className="text-gray leading-relaxed">
+            {error?.message || '일시적인 문제가 발생했습니다.'}
+            <br />
+            잠시 후 다시 시도해주세요.
+          </p>
+          {error?.digest && <p className="text-sm text-gray-500 mt-2">오류 ID: {error.digest}</p>}
+        </div>
+
+        <button
+          onClick={reset}
+          className="inline-flex items-center px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+        >
+          <MdRefresh className="w-4 h-4 mr-2" />
+          다시 시도
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback.tsx
@@ -7,7 +7,7 @@ interface ErrorFallbackProps {
 
 export default function ErrorFallback({ error, reset }: ErrorFallbackProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br flex flex-col items-center justify-center p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center p-4">
       <div className="text-center space-y-6 max-w-md">
         <div className="space-y-2">
           <h1 className="text-8xl font-black text-gray-900 tracking-tight">!</h1>
@@ -16,7 +16,7 @@ export default function ErrorFallback({ error, reset }: ErrorFallbackProps) {
 
         <div className="space-y-3">
           <h2 className="text-2xl font-bold text-gray-800">오류가 발생했습니다</h2>
-          <p className="text-gray leading-relaxed">
+          <p className="text-gray-600 leading-relaxed">
             {error?.message || '일시적인 문제가 발생했습니다.'}
             <br />
             잠시 후 다시 시도해주세요.

--- a/src/components/common/NotFoundMemos.tsx
+++ b/src/components/common/NotFoundMemos.tsx
@@ -1,0 +1,10 @@
+export function NotFoundMemos() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-4">
+      <div className="text-center space-y-3">
+        <h2 className="text-2xl font-bold text-gray-800">메모가 없습니다</h2>
+        <p className="text-gray-500 leading-relaxed">새로운 메모를 추가해보세요.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,3 +1,4 @@
+import { useAuth } from '@/hooks/useAuth';
 import type { CategoryItem } from '@/types/category';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -20,9 +21,11 @@ const fetchCategories = async (): Promise<CategoryItem[]> => {
 };
 
 export default function useCategories() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { data, isLoading, isError } = useQuery<CategoryItem[], Error>({
     queryKey: ['categories'],
     queryFn: fetchCategories,
+    enabled: isAuthenticated && !isAuthLoading,
   });
 
   const categories = useMemo<CategoryItem[]>(() => data || [], [data]);


### PR DESCRIPTION
- 에러 페이지, 로딩 페이지, not-found 페이지 추가
- 카테고리 개별 페이지로 이동시 메모 스켈레톤이 표시되도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 카테고리 페이지 로딩 시 스켈레톤 UI가 표시됩니다.
  - 애플리케이션 전역 에러 처리 및 404(페이지 없음) 페이지가 추가되었습니다.
  - 사용자 친화적인 에러 메시지와 재시도 버튼이 제공되는 에러 UI가 도입되었습니다.
  - 메모가 없을 때 안내 메시지와 추가 권장 문구가 표시됩니다.
  - 로그인 프롬프트 UI가 새롭게 디자인되었습니다.

- **버그 수정**
  - 메모 로딩 실패 시 에러 UI가 개선되었습니다.

- **리팩터**
  - 메모 없음 안내 컴포넌트가 공용 폴더로 이동 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->