### PR TITLE
feat: 카테고리 생성/수정 버튼 클릭 시 입력창에 자동 포커싱

### DIFF
--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -6,7 +6,7 @@ import useCreateCategory from '@/hooks/useCreateCategory';
 import useDeleteCategory from '@/hooks/useDeleteCategory';
 import useModifyCategory from '@/hooks/useModifyCategory';
 import { validateCategoryName } from '@/utils/validateCategoryName';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FaPlus, FaTimes } from 'react-icons/fa';
 import { FaCheck } from 'react-icons/fa6';
 import { HiPencil } from 'react-icons/hi';
@@ -24,6 +24,8 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
     { name: string; isEditing: boolean; isHovered: boolean; editValue: string; error: string }[]
   >([]);
   const [errorMsg, setErrorMsg] = useState('');
+  const createInputRef = useRef<HTMLInputElement>(null);
+  const editInputRef = useRef<(HTMLInputElement | null)[]>([]);
 
   useEffect(() => {
     setCategoryStates(() =>
@@ -225,6 +227,20 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
     }
   };
 
+  useEffect(() => {
+    if(isCreating){
+      createInputRef.current?.focus();
+    }
+  },[isCreating])
+
+  useEffect(() => {
+    categoryStates.forEach((state,idx) => {
+      if(state.isEditing){
+        editInputRef.current[idx]?.focus();
+      }
+    })
+  },[categoryStates])
+
   return (
     <div className="bg-white flex flex-col w-[300px] h-auto min-h-[200px] max-h-[400px] p-4 pr-0 border border-gray-300 rounded-xs overflow-y-auto">
       {isLoading ? (
@@ -255,6 +271,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
                 placeholder="새 카테고리 입력"
                 className="w-[180px] border-b border-gray-300 focus:border-gray-500 focus:outline-none"
                 onKeyDown={handleCategoryCreateKeyDown}
+                ref={createInputRef}
               />
             ) : (
               <div>Create New Category</div>
@@ -298,6 +315,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
                         onChange={e => handleEditInputChange(idx, e.target.value)}
                         onKeyDown={e => handleCategoryModifyKeyDown(e, category.name, idx)}
                         className="w-[180px] border-b border-gray-300 focus:border-gray-500 focus:outline-none"
+                        ref={el => {editInputRef.current[idx] = el}}
                       />
                       {category.error && (
                         <span className="text-xs text-red-600 pt-1 pb-1">{category.error}</span>

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -228,18 +228,19 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   };
 
   useEffect(() => {
-    if(isCreating){
+    if (isCreating) {
       createInputRef.current?.focus();
     }
-  },[isCreating])
+  }, [isCreating]);
 
+  const editingIdx = categoryStates.findIndex(state => state.isEditing);
+  
   useEffect(() => {
-    categoryStates.forEach((state,idx) => {
-      if(state.isEditing){
-        editInputRef.current[idx]?.focus();
-      }
-    })
-  },[categoryStates])
+    // editingIdx가 바뀔 때만 실행되도록 최적화
+    if (editingIdx !== -1) {
+      editInputRef.current[editingIdx]?.focus();
+    }
+  }, [editingIdx]);
 
   return (
     <div className="bg-white flex flex-col w-[300px] h-auto min-h-[200px] max-h-[400px] p-4 pr-0 border border-gray-300 rounded-xs overflow-y-auto">
@@ -315,7 +316,9 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
                         onChange={e => handleEditInputChange(idx, e.target.value)}
                         onKeyDown={e => handleCategoryModifyKeyDown(e, category.name, idx)}
                         className="w-[180px] border-b border-gray-300 focus:border-gray-500 focus:outline-none"
-                        ref={el => {editInputRef.current[idx] = el}}
+                        ref={el => {
+                          editInputRef.current[idx] = el;
+                        }}
                       />
                       {category.error && (
                         <span className="text-xs text-red-600 pt-1 pb-1">{category.error}</span>


### PR DESCRIPTION
## 📋 작업 세부 사항

useEffect를 사용하여 isCreating과 categoryStates가 변경될 때 `ref.current.focus()`가 실행되도록 구현.

수정 시에는 categoryStates가 배열이기 때문에 ref에 배열을 담아줌 
- `  const editInputRef = useRef<(HTMLInputElement | null)[]>([]);`
- editingIdx를 선언하여 useEffect 호출 최적화
  - editingIdx가 변경될 때만 useEffect 실행하도록 함. (`findIndex`로 찾을 때 없으면 값 유지, 있으면 값 변경 -> 그때만 useEffect 실행)
## 🔧 변경 사항 요약

카테고리 생성/수정 버튼 클릭 시 입력창에 자동 포커싱

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 새 카테고리 생성 또는 기존 카테고리 편집 시, 입력창이 자동으로 포커스되어 더욱 편리하게 입력할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->