### PR TITLE
fix: 카테고리 수정 시, 기존 값과 같으면 api 호출을 하지않도록 수정

### DIFF
--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -167,7 +167,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           ),
         );
         return;
-      } else if (categoryName === newCategoryName){
+      } else if (categoryName.toLowerCase() === newCategoryName.toLowerCase()){
         setCategoryStates(prev =>
           prev.map((state, i) =>
             i === index ? { ...state, isEditing: false } : state,

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -167,6 +167,13 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           ),
         );
         return;
+      } else if (categoryName === newCategoryName){
+        setCategoryStates(prev =>
+          prev.map((state, i) =>
+            i === index ? { ...state, isEditing: false } : state,
+          ),
+        );
+        return;
       }
 
       // 로컬 상태만 수정(isEditing / error)

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -167,7 +167,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           ),
         );
         return;
-      } else if (categoryName.toLowerCase() === newCategoryName.toLowerCase()){
+      } else if (categoryName === newCategoryName){
         setCategoryStates(prev =>
           prev.map((state, i) =>
             i === index ? { ...state, isEditing: false } : state,


### PR DESCRIPTION
## 📋 작업 세부 사항

handleModifyClick에서 인자로 받은 `categoryName`과 현재 수정한 `newCategoryName`이 같으면 api를 호출하지 않음.
- categortStates 중에서 현재 index와 같은 값만 isEditing을 false, 나머지는 그대로 사용
- 대소문자 관계 없이 값이 같으면 api 호출하지 않음

## 🔧 변경 사항 요약
기존 값과 같은 카테고리에 대해 api 호출이 이루어지지 않음.

<!-- 주요 변경 사항을 요약해 주세요. -->
![no-api](https://github.com/user-attachments/assets/f7fbd882-f69c-49d3-8ccd-eda0bc0ff99d)

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 카테고리 이름을 수정할 때, 변경 사항이 없으면 불필요한 검증 및 서버 요청 없이 편집 모드만 종료되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->