### PR TITLE
bug: 카테고리 수정을 동시에 여러개 할 수 있던 오류 수정 및 수정/생성 중 하나만 가능하도록 변경

### DIFF
--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -42,7 +42,16 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   }, [fetchedCategories]);
 
   const handlePlusClick = () => {
-    setIsCreating(prev => !prev);
+    // 모든 수정 중 상태 취소
+    setIsCreating(prev => {
+      const next = !prev;
+      if (next) {
+        setCategoryStates(prev => prev.map(state => ({ ...state, isEditing: false })));
+      }
+
+      return next;
+    });
+
     setErrorMsg('');
     setNewCategory('');
   };
@@ -201,6 +210,8 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           error: '',
         })),
       );
+      // 생성 중 상태 취소
+      setIsCreating(false);
     }
   };
 

--- a/src/components/category/CategoryModal.tsx
+++ b/src/components/category/CategoryModal.tsx
@@ -167,11 +167,9 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
           ),
         );
         return;
-      } else if (categoryName === newCategoryName){
+      } else if (categoryName === newCategoryName) {
         setCategoryStates(prev =>
-          prev.map((state, i) =>
-            i === index ? { ...state, isEditing: false } : state,
-          ),
+          prev.map((state, i) => (i === index ? { ...state, isEditing: false } : state)),
         );
         return;
       }
@@ -194,11 +192,14 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
         },
       );
     } else {
-      // isEditing이 false -> true로 바꾸고 수정 모드로 진입
+      // isEditing이 false -> 현재 index만 true로, 나머지는 false로 설정
       setCategoryStates(prev =>
-        prev.map((state, i) =>
-          i === index ? { ...state, editValue: state.name, isEditing: true, error: '' } : state,
-        ),
+        prev.map((state, i) => ({
+          ...state,
+          editValue: i === index ? state.name : state.editValue,
+          isEditing: i === index ? true : false,
+          error: '',
+        })),
       );
     }
   };
@@ -241,7 +242,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
   }, [isCreating]);
 
   const editingIdx = categoryStates.findIndex(state => state.isEditing);
-  
+
   useEffect(() => {
     // editingIdx가 바뀔 때만 실행되도록 최적화
     if (editingIdx !== -1) {
@@ -323,6 +324,7 @@ export default function CategoryModal({ onClose }: { onClose: () => void }) {
                         onChange={e => handleEditInputChange(idx, e.target.value)}
                         onKeyDown={e => handleCategoryModifyKeyDown(e, category.name, idx)}
                         className="w-[180px] border-b border-gray-300 focus:border-gray-500 focus:outline-none"
+                        placeholder={category.name}
                         ref={el => {
                           editInputRef.current[idx] = el;
                         }}


### PR DESCRIPTION
## 📋 작업 세부 사항

카테고리 수정 시, 
선택된 창만 isEditing = true,
나머지는 isEditing = false, 기존 값 유지 되도록 수정

카테고리 생성/수정 모드가 서로 상호 배타적으로 동작하도록 수정(동시에 일어나지 않음)
- 생성모드 on -> 수정모드 off
- 수정모드 on -> 생성모드 off

## 🔧 변경 사항 요약

- 카테고리 수정을 동시에 여러개 할 수 있던 오류 수정
- 수정 input에 placeholder 속성을 추가하여 기존 값을 확인할 수 있도록 수정
- categoryStates의 isEditing이 종료될 때 isCreating(false)로 설정
- isCreating이 종료될 때, categoryStates의 isEditing을 전부 false로 설정

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 카테고리 편집 시 한 번에 하나의 카테고리만 수정할 수 있도록 동작이 개선되었습니다.
  - 편집 입력란에 현재 카테고리 이름이 플레이스홀더로 표시됩니다.
  - 카테고리 편집 모드 전환 시 입력값과 오류 메시지가 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->