### PR TITLE
fix: 에디터에 텍스트량이 많을 때 높이가 늘어나는 문제 해결

### DIFF
--- a/src/components/memo-editor/MemoCreateModal.tsx
+++ b/src/components/memo-editor/MemoCreateModal.tsx
@@ -125,7 +125,7 @@ export default function MemoCreateModal({ onClose }: MemoCreateModalProps) {
                 </div>
               </div>
             </div>
-            <div className="h-full flex-grow pt-4">
+            <div className="h-full flex-grow pt-4 overflow-y-hidden">
               <LexicalMarkdownEditor
                 placeholder="마크다운으로 메모를 작성해보세요..."
                 value={memoData.content}

--- a/src/components/memo-editor/MemoUpdateModal.tsx
+++ b/src/components/memo-editor/MemoUpdateModal.tsx
@@ -183,7 +183,7 @@ export default function MemoUpdateModal({ onClose, id }: MemoUpdateModalProps) {
                 </div>
               </div>
             </div>
-            <div className="h-full flex-grow pt-4">
+            <div className="h-full flex-grow pt-4 overflow-y-hidden">
               <LexicalMarkdownEditor
                 value={displayMemoData.content}
                 onChange={handleMemoContentChange}


### PR DESCRIPTION
- 부모 컴포넌트에 `overflow-y-hidden` 클래스를 추가하여 자식 컴포넌트가 높이를 늘리지 않도록 설정
- 자식 컴포넌트인 에디터 컴포넌트에 `overflow-y-auto` 클래스를 추가하여 스크롤 가능하도록 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 메모 생성 및 수정 모달에서 에디터 영역의 세로 스크롤바와 내용 넘침 현상이 방지되어 더욱 깔끔한 화면을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->